### PR TITLE
add port availability filter to integration tests

### DIFF
--- a/samsa/test/integration.py
+++ b/samsa/test/integration.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import errno
 import itertools
 import logging
 import os
@@ -40,7 +41,7 @@ def is_port_available(port):
         s.close()
         return False
     except IOError, err:
-        return err.errno == 61
+        return err.errno == errno.ECONNREFUSED
 
 
 def merge(*dicts):


### PR DESCRIPTION
verfied by running a kafka broker on 9092, integration suite started
it's broker on the next availabile port (9093). this should allow us to
start multiple brokers in integration tests, if necessary

refs #14
