### PR TITLE
removed version requirement on kazoo

### DIFF
--- a/samsa/__init__.py
+++ b/samsa/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ except ImportError:
     pass
 
 install_requires = [
-    'kazoo>=0.5,<0.7'
+    'kazoo'
 ]
 
 lint_requires = [


### PR DESCRIPTION
The version constraint on kazoo is a holdover from when kazoo was having some issues which have been fixed.
