### PR TITLE
Adding support for Python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
   - "pypy"
 
 notifications:
@@ -18,7 +20,7 @@ before_install:
 
 install:
     - python setup.py develop
-    - pip install --use-mirrors samsa[test]
+    - pip install samsa[test]
 
 env: ZOOKEEPER_PATH=/usr/share/java KAFKA_PATH=/usr/local/kafka KAFKA_START_TIMEOUT=30
 

--- a/samsa/test/case.py
+++ b/samsa/test/case.py
@@ -15,14 +15,17 @@ limitations under the License.
 """
 
 import time
-import unittest2
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest as unittest
 
 from samsa.utils.log import get_logger_for_function
 
 
-class TestCase(unittest2.TestCase):
+class TestCase(unittest.TestCase):
     """
-    A :class:`~unittest2.TestCase` subclass that extra useful test methods.
+    A :class:`~unittest.TestCase` subclass that extra useful test methods.
     """
     def assertPassesWithMultipleAttempts(self, fn, attempts, timeout=1,
             backoff=None, logger=None):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'docs': ['sphinx'] + tests_require,
         'lint': lint_requires
     },
+    use_2to3=True,
     dependency_links=dependency_links,
     zip_safe=False,
     test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ lint_requires = [
     'pyflakes'
 ]
 
-tests_require = ['mock', 'nose', 'unittest2']
+tests_require = ['mock', 'nose']
+if sys.version_info[0] == 2 and sys.version_info[1] == 6:
+    tests_require.append('unittest2')
+
 dependency_links = []
 setup_requires = []
 if 'nosetests' in sys.argv[1:]:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Also --use-mirrors is deprecated.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/parsely/pykafka/106)
<!-- Reviewable:end -->
