### PR TITLE
First steps for the librdkafka-based classes

### DIFF
--- a/samsa/rdsamsa/__init__.py
+++ b/samsa/rdsamsa/__init__.py
@@ -9,7 +9,8 @@ logger = logging.getLogger(__name__)
 
 class Cluster(abstract.Cluster):
     def __init__(self, seed_hosts):
-        self.seed_hosts = seed_hosts
+        self.config = {"metadata.broker.list": seed_hosts}
+        # TODO bind a log_cb to this config ^^
         self._brokers = {}
         self._topics = {}
         self.update()
@@ -23,9 +24,7 @@ class Cluster(abstract.Cluster):
         return self._topics
 
     def update(self):
-        config = {"metadata.broker.list": self.seed_hosts}
-        # TODO bind a log_cb to this config ^^
-        self.meta = rd_kafka.Producer(config).metadata()
+        self.meta = rd_kafka.Producer(self.config).metadata()
 
         self._refresh_no_clobber(self.brokers, self.meta["brokers"], Broker)
         self._refresh_no_clobber(self.topics, self.meta["topics"], Topic)

--- a/samsa/rdsamsa/__init__.py
+++ b/samsa/rdsamsa/__init__.py
@@ -1,0 +1,136 @@
+import logging
+
+import rd_kafka
+from samsa import abstract
+
+
+logger = logging.getLogger(__name__)
+
+
+class Cluster(abstract.Cluster):
+    def __init__(self, seed_hosts):
+        self.seed_hosts = seed_hosts
+        self._brokers = {}
+        self._topics = {}
+        self.update()
+
+    @property
+    def brokers(self):
+        return self._brokers
+
+    @property
+    def topics(self):
+        return self._topics
+
+    def update(self):
+        config = {"metadata.broker.list": self.seed_hosts}
+        # TODO bind a log_cb to this config ^^
+        self.meta = rd_kafka.Producer(config).metadata()
+
+        self._refresh_no_clobber(self.brokers, self.meta["brokers"], Broker)
+        self._refresh_no_clobber(self.topics, self.meta["topics"], Topic)
+        for topic in self.topics.values():
+            self._refresh_no_clobber(
+                    topic.partitions,
+                    self.meta["topics"][topic.name]["partitions"],
+                    Partition,
+                    parent=topic)
+
+    def _refresh_no_clobber(self, target, updates, class_, parent=None):
+        """
+        Add and remove, but do not update existing elements
+
+        As per the spec in samsa.abstract, this avoids replacing elements
+        that may be referenced in other places
+        """
+        removed = set(target.keys()) - set(updates.keys())
+        for key in removed:
+            logger.info("Removing {}".format(target[key]))
+            del target[key]
+        added = set(updates.keys()) - set(target.keys())
+        for key in added:
+            logger.info("Adding {}".format(updates[key]))
+            target[key] = class_(parent or self, key)
+
+
+class Broker(abstract.Broker):
+    """ Just an adapter class for rd_kafka broker metadata """
+
+    def __init__(self, cluster, broker_id):
+        self.cluster = cluster
+        self._id = broker_id
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def host(self):
+        return self.cluster.meta["brokers"][self.id]["host"]
+
+    @property
+    def port(self):
+        return self.cluster.meta["brokers"][self.id]["port"]
+
+
+class Topic(abstract.Topic):
+
+    def __init__(self, cluster, name):
+        self.cluster = cluster
+        self._name = name
+        self._partitions = {}
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def partitions(self):
+        return self._partitions
+
+    def latest_offsets(self):
+        raise NotImplementedError # TODO
+
+    def earliest_offsets(self):
+        raise NotImplementedError # TODO
+
+
+class Partition(object):
+
+    def __init__(self, topic, partition_id):
+        self._topic = topic
+        self._id = partition_id
+
+    def _meta(self):
+        """ Helper that points into the rd_kafka metadata dict """
+        meta, t_name = self.topic.cluster.meta, self.topic.name
+        return meta["topics"][t_name]["partitions"][self.id]
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def leader(self):
+        leader_id = self._meta()["leader"]
+        return self.topic.cluster.brokers[leader_id]
+
+    @property
+    def replicas(self):
+        replica_ids = self._meta()["replicas"]
+        return [self.topic.cluster.brokers[i] for i in replica_ids]
+
+    @property
+    def isr(self):
+        isr_ids = self._meta()["isrs"]
+        return [self.topic.cluster.brokers[i] for i in isr_ids]
+
+    @property
+    def topic(self):
+        return self._topic
+
+    def latest_offset(self):
+        raise NotImplementedError # TODO
+
+    def earliest_offset(self):
+        raise NotImplementedError # TODO

--- a/samsa/rdsamsa/consumer.py
+++ b/samsa/rdsamsa/consumer.py
@@ -1,0 +1,67 @@
+from collections import namedtuple
+from copy import copy
+import logging
+
+import rd_kafka
+from samsa import abstract
+
+
+logger = logging.getLogger(__name__)
+
+
+Message = namedtuple("Message", ["topic", "payload", "key", "offset"])
+# TODO ^^ namedtuple is just a placeholder thingy until we've fleshed out
+#      samsa.common.Message etc
+
+
+class Consumer(abstract.Consumer):
+
+    def __init__(self, client, topic, partitions=None):
+        if isinstance(topic, basestring):
+            topic = client[topic]
+        self._topic = topic
+        self._partitions = partitions or self.topic.partitions # ie all
+
+        config, topic_config = self._configure()
+        rdk_consumer = rd_kafka.Consumer(config)
+        self.rdk_topic = rdk_consumer.open_topic(self.topic.name, topic_config)
+        self.rdk_queue = rdk_consumer.new_queue()
+        for p in self.partitions:
+            if not isinstance(p, int):
+                p = p.id
+            self.rdk_queue.add_toppar(self.rdk_topic, p, start_offset=0)
+            # FIXME ^^ change python-librdkafka to provide default for offset
+            #       (which should probably be OFFSET_STORED)
+
+        # Note that this ^^ uses a new rdk_consumer handle for every instance;
+        # this avoids the confusion of not being allowed a second reader on
+        # the same toppar (a restriction python-librdkafka would impose if
+        # we'd use a common rdk_consumer).  The extra overhead should be
+        # acceptable for most uses.
+
+    def _configure(self):
+        config = copy(self.topic.cluster.config)
+        topic_config = {} # TODO where do we expose this?
+        # TODO config.update( ...stuff like group.id ...)
+
+        return config, topic_config
+
+    @property
+    def topic(self):
+        return self._topic
+
+    @property
+    def partitions(self):
+        return self._partitions # TODO check if Partitions or ints are expected
+
+    def __iter__(self):
+        raise NotImplementedError
+        # TODO implement StopIteration in python-librdkafka
+
+    def consume(self, timeout=1):
+        msg = self.rdk_queue.consume(timeout_ms=1000 * timeout)
+        return None if msg is None else Message(self.topic.name,
+                                                msg.key[:],
+                                                msg.payload[:],
+                                                msg.offset)
+        # XXX copy key/payload to native str in python-librdkafka instead?

--- a/samsa/rdsamsa/producer.py
+++ b/samsa/rdsamsa/producer.py
@@ -1,0 +1,86 @@
+from copy import copy
+import logging
+from time import clock
+
+import rd_kafka
+from samsa import abstract, partitioners
+from samsa.exceptions import SamsaException
+
+
+logger = logging.getLogger(__name__)
+
+
+class Producer(abstract.Producer):
+
+    def __init__(self, topic, partitioner=partitioners.random_partitioner):
+        self._topic = topic
+        self._partitioner = partitioner
+
+        config, topic_config = self._configure()
+        rdk_producer = rd_kafka.Producer(config)
+        self.rdk_topic = rdk_producer.open_topic(self.topic.name, topic_config)
+
+    def _configure(self):
+        config = copy(self.topic.cluster.config)
+        topic_config = {} # TODO where do we expose this?
+        # TODO config.update( ...stuff specific to this Producer ...)
+
+        def delivery_callback(msg, **kwargs):
+            # cf Producer.produce() below to get what this is for
+            msg.opaque.append(msg.cdata.err)
+
+        if "dr_msg_cb" in config:
+            logger.warning("Overwriting user-set delivery callback with ours.")
+        config["dr_msg_cb"] = delivery_callback
+
+        # We'll reuse this librdkafka parameter to set how long we'll wait for
+        # delivery reports (300000 is the current librdkafka default):
+        # TODO move the default to some config header
+        self.message_timeout_ms = config.get("message.timeout.ms", 300 * 1000)
+
+        return config, topic_config
+
+    @property
+    def topic(self):
+        return self._topic
+
+    @property
+    def partitioner(self):
+        return self._partitioner
+
+    def produce(self, messages):
+        """ Sync-producer: raises exceptions on delivery failures """
+        delivery_reports = [list() for _ in range(len(messages))]
+        # This ^^ list of lists is perhaps overly cautious and bulky.  It's
+        # meant to provide thread-safety without locking, but maybe all
+        # delivery callbacks will actually run on one thread.
+
+        for msg, dr in zip(messages, delivery_reports):
+            par = self.partitioner(self.topic.partitions.keys(),
+                                   msg.partition_key)
+            self.rdk_topic.produce(msg.value,
+                                   partition=par,
+                                   msg_opaque=dr)
+        # XXX There may be some batch size at which it becomes more efficient
+        #     to call rd_kafka_produce_batch() instead; or perhaps there isn't,
+        #     because in that approach we'd have to wrap self.partitioner in a
+        #     partitioner-callback.  We should test both implementations.
+
+        timeout_at = clock() + self.message_timeout_ms * .0001
+        while [] in delivery_reports: # ie still waiting for some callbacks
+            if clock() > timeout_at: break
+            self.rdk_topic.kafka_handle.poll()
+
+        failures = False
+        for i, dr in enumerate(delivery_reports):
+            if not dr:
+                logger.error("Delivery report timed out for msg {}".format(i))
+                failures = True
+            elif dr[0] != 0:
+                logger.error("Delivery error {} for msg {}".format(dr[0], i))
+                failures = True
+            else:
+                logger.debug("Successful delivery: {}".format(i))
+        if failures:
+            raise SamsaException("Failed to deliver (some) messages; see log "
+                                 "output for details")


### PR DESCRIPTION
(I thought I'd offer these up before we start renaming "samsa" everywhere :))

The most basic functionality on these classes is in place (refresh metadata, consume from a topic - although not yet at the expected offset! -, produce) but clearly there's more to come. What's needed soon is that we hook up the rd_kafka module in builds, which will allow us to add integration tests.