### PR TITLE
(Re)define produce() method

### DIFF
--- a/kafka/base.py
+++ b/kafka/base.py
@@ -152,4 +152,10 @@ class BaseProducer(object):
 
     @abc.abstractmethod
     def produce(self, messages):
+        """
+        Produce messages to topic
+
+        :type messages: Iterable of strings, or iterable of (key, value) tuples
+                        to produce keyed messages
+        """
         pass

--- a/kafka/rdkafka/producer.py
+++ b/kafka/rdkafka/producer.py
@@ -54,17 +54,18 @@ class Producer(base.BaseProducer):
 
     def produce(self, messages):
         """ Sync-producer: raises exceptions on delivery failures """
-        delivery_reports = [list() for _ in range(len(messages))]
+        delivery_reports = []
         # This ^^ list of lists is perhaps overly cautious and bulky.  It's
         # meant to provide thread-safety without locking, but maybe all
         # delivery callbacks will actually run on one thread.
 
-        for msg, dr in zip(messages, delivery_reports):
+        for msg in messages:
+            delivery_reports.append([])
             par = self.partitioner(self.topic.partitions.keys(),
                                    msg.partition_key)
             self.rdk_topic.produce(msg.value,
                                    partition=par,
-                                   msg_opaque=dr)
+                                   msg_opaque=delivery_reports[-1])
         # XXX There may be some batch size at which it becomes more efficient
         #     to call rd_kafka_produce_batch() instead; or perhaps there isn't,
         #     because in that approach we'd have to wrap self.partitioner in a

--- a/kafka/rdkafka/producer.py
+++ b/kafka/rdkafka/producer.py
@@ -60,10 +60,10 @@ class Producer(base.BaseProducer):
         # delivery callbacks will actually run on one thread.
 
         for msg in messages:
+            key, msg = (None, msg) if isinstance(msg, bytes) else msg
+            par = self.partitioner(self.topic.partitions.keys(), key)
             delivery_reports.append([])
-            par = self.partitioner(self.topic.partitions.keys(),
-                                   msg.partition_key)
-            self.rdk_topic.produce(msg.value,
+            self.rdk_topic.produce(msg,
                                    partition=par,
                                    msg_opaque=delivery_reports[-1])
         # XXX There may be some batch size at which it becomes more efficient


### PR DESCRIPTION
As discussed informally, this is a simple approach to enabling both keyed and unkeyed message produce-requests.