### PR TITLE
[WIP] Balanced Consumer

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -39,6 +39,7 @@ class KafkaClient(object):
                  hosts='127.0.0.1:9092',
                  use_greenlets=False,
                  socket_timeout_ms=30 * 1000,
+                 offsets_channel_socket_timeout_ms=10 * 1000,
                  ignore_rdkafka=False,
                  socket_receive_buffer_bytes=64 * 1024,
                  exclude_internal_topics=True):
@@ -48,6 +49,9 @@ class KafkaClient(object):
         :param use_greenlets: If True, use gevent instead of threading.
         :param socket_timeout_ms: the socket timeout for network requests
         :type socket_timeout_ms: int
+        :param offsets_channel_socket_timeout_ms: Socket timeout when reading
+            responses for offset fetch/commit requests.
+        :type offsets_channel_socket_timeout_ms: int
         :param ignore_rdkafka: Don't use rdkafka, even if installed.
         :param socket_receive_buffer_bytes: the size of the socket receive
             buffer for network requests
@@ -57,7 +61,8 @@ class KafkaClient(object):
         :type exclude_internal_topics: bool
         """
         self._seed_hosts = hosts
-        self._timeout = socket_timeout_ms
+        self._socket_timeout_ms = socket_timeout_ms
+        self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._handler = None if use_greenlets else handlers.ThreadingHandler()
         self._use_rdkafka = rd_kafka and not ignore_rdkafka
         if self._use_rdkafka:
@@ -67,7 +72,8 @@ class KafkaClient(object):
             self.cluster = pykafka.Cluster(
                 self._seed_hosts,
                 self._handler,
-                self._timeout,
+                socket_timeout_ms=self._socket_timeout_ms,
+                offsets_channel_socket_timeout_ms=self._offsets_channel_socket_timeout_ms,
                 socket_receive_buffer_bytes=socket_receive_buffer_bytes,
                 exclude_internal_topics=exclude_internal_topics
             )

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -39,13 +39,17 @@ class KafkaClient(object):
                  hosts='127.0.0.1:9092',
                  use_greenlets=False,
                  timeout=30,
-                 ignore_rdkafka=False):
+                 ignore_rdkafka=False,
+                 socket_receive_buffer_bytes=64 * 1024):
         """Create a connection to a Kafka cluster.
 
         :param hosts: Comma separated list of seed hosts to used to connect.
         :param use_greenlets: If True, use gevent instead of threading.
         :param timeout: Connection timeout, in seconds.
         :param ignore_rdkafka: Don't use rdkafka, even if installed.
+        :param socket_receive_buffer_bytes: the size of the socket receive
+            buffer for network requests
+        :type socket_receive_buffer_bytes: int
         """
         self._seed_hosts = hosts
         self._timeout = timeout
@@ -55,9 +59,12 @@ class KafkaClient(object):
             logger.info('Using rd_kafka extensions.')
             raise NotImplementedError('Not yet')
         else:
-            self.cluster = pykafka.Cluster(self._seed_hosts,
-                                           self._handler,
-                                           self._timeout)
+            self.cluster = pykafka.Cluster(
+                self._seed_hosts,
+                self._handler,
+                self._timeout,
+                socket_receive_buffer_bytes=socket_receive_buffer_bytes
+            )
         self.brokers = self.cluster.brokers
         self.topics = self.cluster.topics
 

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -37,6 +37,7 @@ class KafkaClient(object):
     """
     def __init__(self,
                  hosts='127.0.0.1:9092',
+                 zk_host='127.0.0.1:2181',
                  use_greenlets=False,
                  timeout=30,
                  ignore_rdkafka=False):
@@ -49,6 +50,7 @@ class KafkaClient(object):
         """
         self._seed_hosts = hosts
         self._timeout = timeout
+        self._zk_host = zk_host
         self._handler = None if use_greenlets else handlers.ThreadingHandler()
         self._use_rdkafka = rd_kafka and not ignore_rdkafka
         if self._use_rdkafka:
@@ -56,6 +58,7 @@ class KafkaClient(object):
             raise NotImplementedError('Not yet')
         else:
             self.cluster = pykafka.Cluster(self._seed_hosts,
+                                           self._zk_host,
                                            self._handler,
                                            self._timeout)
         self.brokers = self.cluster.brokers

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -38,21 +38,22 @@ class KafkaClient(object):
     def __init__(self,
                  hosts='127.0.0.1:9092',
                  use_greenlets=False,
-                 timeout=30,
+                 socket_timeout_ms=30 * 1000,
                  ignore_rdkafka=False,
                  socket_receive_buffer_bytes=64 * 1024):
         """Create a connection to a Kafka cluster.
 
         :param hosts: Comma separated list of seed hosts to used to connect.
         :param use_greenlets: If True, use gevent instead of threading.
-        :param timeout: Connection timeout, in seconds.
+        :param socket_timeout_ms: the socket timeout for network requests
+        :type socket_timeout_ms: int
         :param ignore_rdkafka: Don't use rdkafka, even if installed.
         :param socket_receive_buffer_bytes: the size of the socket receive
             buffer for network requests
         :type socket_receive_buffer_bytes: int
         """
         self._seed_hosts = hosts
-        self._timeout = timeout
+        self._timeout = socket_timeout_ms
         self._handler = None if use_greenlets else handlers.ThreadingHandler()
         self._use_rdkafka = rd_kafka and not ignore_rdkafka
         if self._use_rdkafka:

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -37,7 +37,6 @@ class KafkaClient(object):
     """
     def __init__(self,
                  hosts='127.0.0.1:9092',
-                 zk_host='127.0.0.1:2181',
                  use_greenlets=False,
                  timeout=30,
                  ignore_rdkafka=False):
@@ -50,7 +49,6 @@ class KafkaClient(object):
         """
         self._seed_hosts = hosts
         self._timeout = timeout
-        self._zk_host = zk_host
         self._handler = None if use_greenlets else handlers.ThreadingHandler()
         self._use_rdkafka = rd_kafka and not ignore_rdkafka
         if self._use_rdkafka:
@@ -58,7 +56,6 @@ class KafkaClient(object):
             raise NotImplementedError('Not yet')
         else:
             self.cluster = pykafka.Cluster(self._seed_hosts,
-                                           self._zk_host,
                                            self._handler,
                                            self._timeout)
         self.brokers = self.cluster.brokers

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -40,7 +40,8 @@ class KafkaClient(object):
                  use_greenlets=False,
                  socket_timeout_ms=30 * 1000,
                  ignore_rdkafka=False,
-                 socket_receive_buffer_bytes=64 * 1024):
+                 socket_receive_buffer_bytes=64 * 1024,
+                 exclude_internal_topics=True):
         """Create a connection to a Kafka cluster.
 
         :param hosts: Comma separated list of seed hosts to used to connect.
@@ -51,6 +52,9 @@ class KafkaClient(object):
         :param socket_receive_buffer_bytes: the size of the socket receive
             buffer for network requests
         :type socket_receive_buffer_bytes: int
+        :param exclude_internal_topics: Whether messages from internal topics
+            (such as offsets) should be exposed to the consumer.
+        :type exclude_internal_topics: bool
         """
         self._seed_hosts = hosts
         self._timeout = socket_timeout_ms
@@ -64,7 +68,8 @@ class KafkaClient(object):
                 self._seed_hosts,
                 self._handler,
                 self._timeout,
-                socket_receive_buffer_bytes=socket_receive_buffer_bytes
+                socket_receive_buffer_bytes=socket_receive_buffer_bytes,
+                exclude_internal_topics=exclude_internal_topics
             )
         self.brokers = self.cluster.brokers
         self.topics = self.cluster.topics

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -116,6 +116,8 @@ class BalancedConsumer():
         self._fetch_wait_max_ms = fetch_wait_max_ms
         self._rebalance_backoff_ms = rebalance_backoff_ms
         self._consumer_timeout_ms = consumer_timeout_ms
+        self._offsets_channel_backoff_ms = offsets_channel_backoff_ms
+        self._offsets_commit_max_retries = offsets_commit_max_retries
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -169,7 +171,9 @@ class BalancedConsumer():
             num_consumer_fetchers=self._num_consumer_fetchers,
             queued_max_messages=self._queued_max_messages,
             fetch_wait_max_ms=self._fetch_wait_max_ms,
-            consumer_timeout_ms=self._consumer_timeout_ms
+            consumer_timeout_ms=self._consumer_timeout_ms,
+            offsets_channel_backoff_ms=self._offsets_channel_backoff_ms,
+            offsets_commit_max_retries=self._offsets_commit_max_retries
         )
 
     def _decide_partitions(self, participants):

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -25,7 +25,6 @@ class BalancedConsumer():
                  topic,
                  cluster,
                  consumer_group,
-                 zookeeper_connect='127.0.0.1:2181',
                  fetch_message_max_bytes=1024 * 1024,
                  num_consumer_fetchers=1,
                  auto_commit_enable=False,
@@ -41,7 +40,8 @@ class BalancedConsumer():
                  consumer_timeout_ms=-1,
                  rebalance_max_retries=5,
                  rebalance_backoff_ms=2 * 1000,
-                 zookeeper_connection_timeout_ms=6 * 1000):
+                 zookeeper_connection_timeout_ms=6 * 1000,
+                 zookeeper_connect='127.0.0.1:2181'):
         """Create a BalancedConsumer
 
         Maintains a single instance of SimpleConsumer, periodically using the
@@ -54,9 +54,6 @@ class BalancedConsumer():
         :type cluster: pykafka.cluster.Cluster
         :param consumer_group: the name of the consumer group to join
         :type consumer_group: str
-        :param zookeeper_connect: comma separated ip:port strings of the
-            zookeeper nodes to connect to
-        :type zookeeper_connect: str
         :param fetch_message_max_bytes: the number of bytes of messages to
             attempt to fetch
         :type fetch_message_max_bytes: int
@@ -107,6 +104,9 @@ class BalancedConsumer():
         :param zookeeper_connection_timeout_ms: The max time that the client
             waits while establishing a connection to zookeeper.
         :type zookeeper_connection_timeout_ms: int
+        :param zookeeper_connect: comma separated ip:port strings of the
+            zookeeper nodes to connect to
+        :type zookeeper_connect: str
         """
         if not isinstance(cluster, weakref.ProxyType):
             self._cluster = weakref.proxy(cluster)

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -34,7 +34,8 @@ class BalancedConsumer():
                  offsets_commit_max_retries=5,
                  auto_offset_reset=OffsetType.LATEST,
                  consumer_timeout_ms=-1,
-                 rebalance_max_retries=5):
+                 rebalance_max_retries=5,
+                 rebalance_backoff_ms=2 * 1000):
         """Create a BalancedConsumer
 
         Maintains a single instance of SimpleConsumer, periodically using the
@@ -95,6 +96,8 @@ class BalancedConsumer():
         :param rebalance_max_retries: Maximum number of attempts before failing to
             rebalance
         :type rebalance_max_retries: int
+        :param rebalance_backoff_ms: Backoff time between retries during rebalance.
+        :type rebalance_backoff_ms: int
         """
         if not isinstance(cluster, weakref.ProxyType):
             self._cluster = weakref.proxy(cluster)
@@ -304,8 +307,8 @@ class BalancedConsumer():
             except NodeExistsError:
                 log.debug("Partition still owned")
 
-            log.debug("Retrying in %is" % ((i + 1) ** 2))
-            time.sleep(i ** 2)
+            log.debug("Retrying")
+            time.sleep(i * (float(self._rebalance_backoff_ms) / 1000.0))
 
         self._setup_internal_consumer()
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -113,6 +113,7 @@ class BalancedConsumer():
         self._fetch_min_bytes = fetch_min_bytes
         self._rebalance_retries = rebalance_retries
         self._num_consumer_fetchers = num_consumer_fetchers
+        self._queued_max_messages = queued_max_messages
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -168,7 +169,8 @@ class BalancedConsumer():
             socket_timeout_ms=self._socket_timeout_ms,
             fetch_message_max_bytes=self._fetch_message_max_bytes,
             fetch_min_bytes=self._fetch_min_bytes,
-            num_consumer_fetchers=self._num_consumer_fetchers
+            num_consumer_fetchers=self._num_consumer_fetchers,
+            queued_max_messages=self._queued_max_messages
         )
 
     def _decide_partitions(self, participants):

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -277,7 +277,7 @@ class BalancedConsumer():
             log.debug("More consumers than partitions.")
             return
 
-        path = '{}/{}'.format(self._consumer_id_path, self._id)
+        path = '{}/{}'.format(self._consumer_id_path, self._consumer_id)
         self._zookeeper.create(
             path, self._topic.name, ephemeral=True, makepath=True)
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -105,12 +105,12 @@ class BalancedConsumer():
 
         self._auto_commit_enable = auto_commit_enable
         self._auto_commit_interval_ms = auto_commit_interval_ms
-        self._socket_timeout_ms = socket_timeout_ms
         self._fetch_message_max_bytes = fetch_message_max_bytes
         self._fetch_min_bytes = fetch_min_bytes
-        self._rebalance_retries = rebalance_retries
+        self._rebalance_max_retries = rebalance_max_retries
         self._num_consumer_fetchers = num_consumer_fetchers
         self._queued_max_messages = queued_max_messages
+        self._fetch_wait_max_ms = fetch_wait_max_ms
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -163,11 +163,11 @@ class BalancedConsumer():
             partitions=list(self._partitions),
             auto_commit_enable=self._auto_commit_enable,
             auto_commit_interval_ms=self._auto_commit_interval_ms,
-            socket_timeout_ms=self._socket_timeout_ms,
             fetch_message_max_bytes=self._fetch_message_max_bytes,
             fetch_min_bytes=self._fetch_min_bytes,
             num_consumer_fetchers=self._num_consumer_fetchers,
-            queued_max_messages=self._queued_max_messages
+            queued_max_messages=self._queued_max_messages,
+            fetch_wait_max_ms=self._fetch_wait_max_ms
         )
 
     def _decide_partitions(self, participants):

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -14,7 +14,8 @@ from kazoo.recipe.watchers import ChildrenWatch
 from kafka.common import OffsetType
 from kafka.pykafka.simpleconsumer import SimpleConsumer
 
-# TODO - support refresh.leader.backoff.ms option
+# TODO - support refresh_leader_backoff_ms option
+# TODO - support auto_offset_reset option
 
 
 class BalancedConsumer():

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -21,7 +21,6 @@ class BalancedConsumer():
                  cluster,
                  consumer_group,
                  zookeeper_connect='127.0.0.1:2181',
-                 socket_timeout_ms=30 * 1000,
                  fetch_message_max_bytes=1024 * 1024,
                  num_consumer_fetchers=1,
                  auto_commit_enable=False,
@@ -51,8 +50,6 @@ class BalancedConsumer():
         :param zookeeper_connect: comma separated ip:port strings of the
             zookeeper nodes to connect to
         :type zookeeper_connect: str
-        :param socket_timeout_ms: the socket timeout for network requests
-        :type socket_timeout_ms: int
         :param fetch_message_max_bytes: the number of bytes of messages to
             attempt to fetch
         :type fetch_message_max_bytes: int

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -118,6 +118,7 @@ class BalancedConsumer():
         self._consumer_timeout_ms = consumer_timeout_ms
         self._offsets_channel_backoff_ms = offsets_channel_backoff_ms
         self._offsets_commit_max_retries = offsets_commit_max_retries
+        self._auto_offset_reset = auto_offset_reset
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -173,7 +174,8 @@ class BalancedConsumer():
             fetch_wait_max_ms=self._fetch_wait_max_ms,
             consumer_timeout_ms=self._consumer_timeout_ms,
             offsets_channel_backoff_ms=self._offsets_channel_backoff_ms,
-            offsets_commit_max_retries=self._offsets_commit_max_retries
+            offsets_commit_max_retries=self._offsets_commit_max_retries,
+            auto_offset_reset=self._auto_offset_reset
         )
 
     def _decide_partitions(self, participants):

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -2,5 +2,33 @@ from kafka.pykafka.simpleconsumer import SimpleConsumer
 
 
 class BalancedConsumer():
-    def __init__(self):
-        pass
+    def __init__(self,
+                 topic,
+                 cluster,
+                 consumer_group):
+        """Create a BalancedConsumer
+
+        :param topic: the topic this consumer should consume
+        :type topic: pykafka.topic.Topic
+        :param cluster: the cluster this consumer should connect to
+        :type cluster: pykafka.cluster.Cluster
+        :param consumer_group: the name of the consumer group to join
+        :type consumer_group: str
+        """
+        self._cluster = cluster
+        self._consumer_group = consumer_group
+        self._topic = topic
+
+    def _setup_internal_consumer(self):
+        participants = self._get_participants()
+        partitions = self._decide_partitions(participants)
+        return SimpleConsumer(self._topic,
+                              self._cluster,
+                              consumer_group=self._consumer_group,
+                              partitions=partitions)
+
+    def _decide_partitions(self, participants):
+        return []
+
+    def _get_participants(self):
+        return []

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -34,7 +34,7 @@ class BalancedConsumer():
                  offsets_commit_max_retries=5,
                  auto_offset_reset=OffsetType.LATEST,
                  consumer_timeout_ms=-1,
-                 rebalance_retries=5):
+                 rebalance_max_retries=5):
         """Create a BalancedConsumer
 
         Maintains a single instance of SimpleConsumer, periodically using the
@@ -92,9 +92,9 @@ class BalancedConsumer():
             if no message is available for consumption after the specified
             interval
         :type consumer_timeout_ms: int
-        :param rebalance_retries: Maximum number of attempts before failing to
+        :param rebalance_max_retries: Maximum number of attempts before failing to
             rebalance
-        :type rebalance_retries: int
+        :type rebalance_max_retries: int
         """
         if not isinstance(cluster, weakref.ProxyType):
             self._cluster = weakref.proxy(cluster)
@@ -292,7 +292,7 @@ class BalancedConsumer():
             self._consumer_id, self._topic.name)
         )
 
-        for i in xrange(self._rebalance_retries):
+        for i in xrange(self._rebalance_max_retries):
             participants = self._get_participants()
             new_partitions = self._decide_partitions(participants)
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -117,6 +117,7 @@ class BalancedConsumer():
         self._queued_max_messages = queued_max_messages
         self._fetch_wait_max_ms = fetch_wait_max_ms
         self._rebalance_backoff_ms = rebalance_backoff_ms
+        self._consumer_timeout_ms = consumer_timeout_ms
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -174,7 +175,8 @@ class BalancedConsumer():
             fetch_min_bytes=self._fetch_min_bytes,
             num_consumer_fetchers=self._num_consumer_fetchers,
             queued_max_messages=self._queued_max_messages,
-            fetch_wait_max_ms=self._fetch_wait_max_ms
+            fetch_wait_max_ms=self._fetch_wait_max_ms,
+            consumer_timeout_ms=self._consumer_timeout_ms
         )
 
     def _decide_partitions(self, participants):

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -14,12 +14,6 @@ from kazoo.recipe.watchers import ChildrenWatch
 from kafka.common import OffsetType
 from kafka.pykafka.simpleconsumer import SimpleConsumer
 
-# TODO - support refresh_leader_backoff_ms option
-# TODO - support auto_offset_reset option
-# zookeeper.session.timeout.ms
-# zookeeper.sync.time.ms
-# offsets.channel.socket.timeout.ms
-
 
 class BalancedConsumer():
     def __init__(self,

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -129,6 +129,7 @@ class BalancedConsumer():
 
         def _close_zk_connection(signum, frame):
             self._zookeeper.stop()
+            self._consumer.stop()
             sys.exit()
         signal.signal(signal.SIGINT, _close_zk_connection)
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -1,11 +1,12 @@
+from __future__ import division
 import itertools
 import logging as log
 import signal
 import socket
 import sys
 import time
-from uuid import uuid4
 import weakref
+from uuid import uuid4
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeException, NodeExistsError
@@ -146,17 +147,9 @@ class BalancedConsumer():
         :param timeout: connection timeout in milliseconds
         :type timeout: int
         """
-        zk = None
-        hosts = zookeeper_connect.split(',')
-        for host in hosts:
-            try:
-                zk = KazooClient(host, timeout=float(timeout) / 1000.0)
-                break
-            except:
-                log.debug("Connecting to zookeeper at %s failed.", host)
-        if zk is not None:
-            zk.start()
-            return zk
+        zk = KazooClient(zookeeper_connect, timeout=timeout / 1000)
+        zk.start()
+        return zk
 
     def _setup_internal_consumer(self):
         """Create an internal SimpleConsumer instance
@@ -315,7 +308,7 @@ class BalancedConsumer():
                 log.debug("Partition still owned")
 
             log.debug("Retrying")
-            time.sleep(i * (float(self._rebalance_backoff_ms) / 1000.0))
+            time.sleep(i * (self._rebalance_backoff_ms / 1000))
 
         self._setup_internal_consumer()
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -12,6 +12,7 @@ from kazoo.recipe.watchers import ChildrenWatch
 
 from kafka.common import OffsetType
 from kafka.pykafka.simpleconsumer import SimpleConsumer
+from kafka.exceptions import KafkaException
 
 
 class BalancedConsumer():
@@ -284,8 +285,7 @@ class BalancedConsumer():
         """
         participants = self._get_participants()
         if len(self._topic.partitions) <= len(participants):
-            log.debug("More consumers than partitions.")
-            return
+            raise KafkaException("Cannot add consumer: more consumers than partitions")
 
         path = '{}/{}'.format(self._consumer_id_path, self._consumer_id)
         self._zookeeper.create(

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -18,6 +18,7 @@ from kafka.pykafka.simpleconsumer import SimpleConsumer
 # TODO - support auto_offset_reset option
 # zookeeper.session.timeout.ms
 # zookeeper.sync.time.ms
+# offsets.channel.socket.timeout.ms
 
 
 class BalancedConsumer():
@@ -34,7 +35,6 @@ class BalancedConsumer():
                  fetch_wait_max_ms=100,
                  refresh_leader_backoff_ms=200,
                  offsets_channel_backoff_ms=1000,
-                 offsets_channel_socket_timeout_ms=10000,
                  offsets_commit_max_retries=5,
                  auto_offset_reset=OffsetType.LATEST,
                  consumer_timeout_ms=-1,
@@ -82,11 +82,6 @@ class BalancedConsumer():
         :param offsets_channel_backoff_ms: backoff time to retry offset
             commits/fetches
         :type offsets_channel_backoff_ms: int
-        :param offsets_channel_socket_timeout_ms: socket timeout to use when
-            reading responses for Offset Fetch/Commit requests. This timeout
-            will also be used for the ConsumerMetdata requests that are used
-            to query for the offset coordinator.
-        :type offsets_channel_socket_timeout_ms: int
         :param offsets_commit_max_retries: Retry the offset commit up to this
             many times on failure.
         :type offsets_commit_max_retries: int

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -146,10 +146,12 @@ class BalancedConsumer():
         :param timeout: connection timeout in milliseconds
         :type timeout: int
         """
+        zk = None
         hosts = zookeeper_connect.split(',')
         for host in hosts:
             try:
-                zk = KazooClient(host=host, timeout=float(timeout) / 1000.0)
+                zk = KazooClient(host, timeout=float(timeout) / 1000.0)
+                break
             except:
                 log.debug("Connecting to zookeeper at %s failed.", host)
         if zk is not None:

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -15,7 +15,10 @@ class BalancedConsumer():
                  topic,
                  cluster,
                  consumer_group,
-                 zk_host='127.0.0.1:2181'):
+                 zk_host='127.0.0.1:2181',
+                 auto_commit_enable=False,
+                 auto_commit_interval_ms=60 * 1000,
+                 socket_timeout_ms=30000):
         """Create a BalancedConsumer
 
         :param topic: the topic this consumer should consume
@@ -30,6 +33,10 @@ class BalancedConsumer():
         self._cluster = cluster
         self._consumer_group = consumer_group
         self._topic = topic
+
+        self._auto_commit_enable = auto_commit_enable
+        self._auto_commit_interval_ms = auto_commit_interval_ms
+        self._socket_timeout_ms = socket_timeout_ms
 
         self._id_path = '/consumers/{}/ids'.format(self._consumer_group)
         self._id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -49,7 +56,10 @@ class BalancedConsumer():
         return SimpleConsumer(self._topic,
                               self._cluster,
                               consumer_group=self._consumer_group,
-                              partitions=partitions)
+                              partitions=partitions,
+                              auto_commit_enable=self._auto_commit_enable,
+                              auto_commit_interval_ms=self._auto_commit_interval_ms,
+                              socket_timeout_ms=self._socket_timeout_ms)
 
     def _decide_partitions(self, participants):
         # Freeze and sort partitions so we always have the same results

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -14,6 +14,8 @@ from kazoo.recipe.watchers import ChildrenWatch
 from kafka.common import OffsetType
 from kafka.pykafka.simpleconsumer import SimpleConsumer
 
+# TODO - support refresh.leader.backoff.ms option
+
 
 class BalancedConsumer():
     def __init__(self,
@@ -114,6 +116,7 @@ class BalancedConsumer():
         self._num_consumer_fetchers = num_consumer_fetchers
         self._queued_max_messages = queued_max_messages
         self._fetch_wait_max_ms = fetch_wait_max_ms
+        self._rebalance_backoff_ms = rebalance_backoff_ms
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -34,7 +34,8 @@ class BalancedConsumer():
                  rebalance_max_retries=5,
                  rebalance_backoff_ms=2 * 1000,
                  zookeeper_connection_timeout_ms=6 * 1000,
-                 zookeeper_connect='127.0.0.1:2181'):
+                 zookeeper_connect='127.0.0.1:2181',
+                 zookeeper=None):
         """Create a BalancedConsumer
 
         Maintains a single instance of SimpleConsumer, periodically using the
@@ -95,6 +96,8 @@ class BalancedConsumer():
         :param zookeeper_connect: comma separated ip:port strings of the
             zookeeper nodes to connect to
         :type zookeeper_connect: str
+        :param zookeeper: A KazooClient connected to a Zookeeper instance
+        :type zookeeper: kazoo.client.KazooClient
         """
         if not isinstance(cluster, weakref.ProxyType):
             self._cluster = weakref.proxy(cluster)
@@ -123,8 +126,8 @@ class BalancedConsumer():
                                                             self._topic.name)
         self._consumer_id_path = '/consumers/{}/ids'.format(self._consumer_group)
 
-        self._zookeeper = self._setup_zookeeper(zookeeper_connect,
-                                                zookeeper_connection_timeout_ms)
+        self._zookeeper = zookeeper or self._setup_zookeeper(
+            zookeeper_connect, zookeeper_connection_timeout_ms)
         self._zookeeper.ensure_path(self._topic_path)
         self._add_self()
         self._set_watches()

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -1,6 +1,7 @@
 import logging as log
 
 from kazoo.exceptions import NoNodeException
+from kazoo.client import KazooClient
 
 from kafka.pykafka.simpleconsumer import SimpleConsumer
 
@@ -9,7 +10,8 @@ class BalancedConsumer():
     def __init__(self,
                  topic,
                  cluster,
-                 consumer_group):
+                 consumer_group,
+                 zk_host='127.0.0.1:2181'):
         """Create a BalancedConsumer
 
         :param topic: the topic this consumer should consume
@@ -22,7 +24,14 @@ class BalancedConsumer():
         self._cluster = cluster
         self._consumer_group = consumer_group
         self._topic = topic
+
+        self._zookeeper = self._setup_zookeeper(zk_host)
         self._consumer = self._setup_internal_consumer()
+
+    def _setup_zookeeper(self, zk_host):
+        zk = KazooClient(zk_host)
+        zk.start()
+        return zk
 
     def _setup_internal_consumer(self):
         participants = self._get_participants()

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -30,11 +30,11 @@ class BalancedConsumer():
         self._consumer_group = consumer_group
         self._topic = topic
 
+        self._id_path = '/consumers/{}/ids'.format(self._consumer_group)
+        self._id = "{}:{}".format(socket.gethostname(), uuid4())
+
         self._zookeeper = self._setup_zookeeper(zk_host)
         self._consumer = self._setup_internal_consumer()
-
-        self._id_path = '/consumers/{}/ids'.format(self.consumer_group)
-        self._id = "{}:{}".format(socket.gethostname(), uuid4())
 
     def _setup_zookeeper(self, zk_host):
         zk = KazooClient(zk_host)
@@ -51,8 +51,8 @@ class BalancedConsumer():
 
     def _decide_partitions(self, participants):
         # Freeze and sort partitions so we always have the same results
-        p_to_str = lambda p: '-'.join([p.topic.name, str(p.broker.id)])
-        all_partitions = list(self._topic.partitions)
+        p_to_str = lambda p: '-'.join([p.topic.name, str(p.leader.id)])
+        all_partitions = list(self._topic.partitions.values())
         all_partitions.sort(key=p_to_str)
 
         # get start point, # of partitions, and remainder

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -112,6 +112,7 @@ class BalancedConsumer():
         self._fetch_message_max_bytes = fetch_message_max_bytes
         self._fetch_min_bytes = fetch_min_bytes
         self._rebalance_retries = rebalance_retries
+        self._num_consumer_fetchers = num_consumer_fetchers
 
         self._consumer = None
         self._consumer_id = "{}:{}".format(socket.gethostname(), uuid4())
@@ -166,7 +167,9 @@ class BalancedConsumer():
             auto_commit_interval_ms=self._auto_commit_interval_ms,
             socket_timeout_ms=self._socket_timeout_ms,
             fetch_message_max_bytes=self._fetch_message_max_bytes,
-            fetch_min_bytes=self._fetch_min_bytes)
+            fetch_min_bytes=self._fetch_min_bytes,
+            num_consumer_fetchers=self._num_consumer_fetchers
+        )
 
     def _decide_partitions(self, participants):
         """Decide which partitions belong to this consumer

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -5,6 +5,7 @@ import socket
 import sys
 import time
 from uuid import uuid4
+import weakref
 
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeException, NodeExistsError
@@ -98,7 +99,10 @@ class BalancedConsumer():
             rebalance
         :type rebalance_retries: int
         """
-        self._cluster = cluster
+        if not isinstance(cluster, weakref.ProxyType):
+            self._cluster = weakref.proxy(cluster)
+        else:
+            self._cluster = cluster
         self._consumer_group = consumer_group
         self._topic = topic
 

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -1,0 +1,6 @@
+from kafka.pykafka.simpleconsumer import SimpleConsumer
+
+
+class BalancedConsumer():
+    def __init__(self):
+        pass

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -21,7 +21,6 @@ class BalancedConsumer():
                  consumer_group,
                  zookeeper_connect='127.0.0.1:2181',
                  socket_timeout_ms=30 * 1000,
-                 socket_receive_buffer_bytes=60 * 1024,
                  fetch_message_max_bytes=1024 * 1024,
                  num_consumer_fetchers=1,
                  auto_commit_enable=False,
@@ -53,9 +52,6 @@ class BalancedConsumer():
         :type zookeeper_connect: str
         :param socket_timeout_ms: the socket timeout for network requests
         :type socket_timeout_ms: int
-        :param socket_receive_buffer_bytes: the size of the socket receive
-            buffer for network requests
-        :type socket_receive_buffer_bytes: int
         :param fetch_message_max_bytes: the number of bytes of messages to
             attempt to fetch
         :type fetch_message_max_bytes: int

--- a/kafka/pykafka/balancedconsumer.py
+++ b/kafka/pykafka/balancedconsumer.py
@@ -1,9 +1,7 @@
 from __future__ import division
 import itertools
 import logging as log
-import signal
 import socket
-import sys
 import time
 import weakref
 from uuid import uuid4
@@ -125,18 +123,16 @@ class BalancedConsumer():
                                                             self._topic.name)
         self._consumer_id_path = '/consumers/{}/ids'.format(self._consumer_group)
 
-        def _close_zk_connection(signum, frame):
-            self._zookeeper.stop()
-            self._consumer.stop()
-            sys.exit()
-        signal.signal(signal.SIGINT, _close_zk_connection)
-
         self._zookeeper = self._setup_zookeeper(zookeeper_connect,
                                                 zookeeper_connection_timeout_ms)
         self._zookeeper.ensure_path(self._topic_path)
         self._add_self()
         self._set_watches()
         self._rebalance()
+
+    def stop(self):
+        self._zookeeper.stop()
+        self._consumer.stop()
 
     def _setup_zookeeper(self, zookeeper_connect, timeout):
         """Open a connection to a ZooKeeper host

--- a/kafka/pykafka/broker.py
+++ b/kafka/pykafka/broker.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 
 class Broker(base.BaseBroker):
 
-    def __init__(self, id_, host, port, handler, timeout,
+    def __init__(self,
+                 id_,
+                 host,
+                 port,
+                 handler,
+                 timeout,
                  buffer_size=64 * 1024):
         """Init a Broker.
 

--- a/kafka/pykafka/broker.py
+++ b/kafka/pykafka/broker.py
@@ -21,7 +21,8 @@ class Broker(base.BaseBroker):
                  host,
                  port,
                  handler,
-                 timeout,
+                 socket_timeout_ms,
+                 offsets_channel_socket_timeout_ms,
                  buffer_size=64 * 1024):
         """Init a Broker.
 
@@ -38,7 +39,8 @@ class Broker(base.BaseBroker):
         self._handler = handler
         self._req_handler = None
         self._offsets_channel_req_handler = None
-        self._timeout = timeout
+        self._socket_timeout_ms = socket_timeout_ms
+        self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._buffer_size = buffer_size
         self.connect()
 
@@ -46,7 +48,8 @@ class Broker(base.BaseBroker):
     def from_metadata(cls,
                       metadata,
                       handler,
-                      timeout,
+                      socket_timeout_ms,
+                      offsets_channel_socket_timeout_ms,
                       buffer_size=64 * 1024):
         """ Create a Broker using BrokerMetadata
 
@@ -54,7 +57,8 @@ class Broker(base.BaseBroker):
         :type metadata: :class:`kafka.pykafka.protocol.BrokerMetadata.`
         """
         return cls(metadata.id, metadata.host,
-                   metadata.port, handler, timeout,
+                   metadata.port, handler, socket_timeout_ms,
+                   offsets_channel_socket_timeout_ms,
                    buffer_size=buffer_size)
 
     @property
@@ -101,7 +105,7 @@ class Broker(base.BaseBroker):
     def connect(self):
         """Establish a connection to the Broker."""
         conn = BrokerConnection(self.host, self.port, self._buffer_size)
-        conn.connect(self._timeout)
+        conn.connect(self._socket_timeout_ms)
         self._req_handler = RequestHandler(self._handler, conn)
         self._req_handler.start()
         self._connected = True
@@ -109,7 +113,7 @@ class Broker(base.BaseBroker):
     def connect_offsets_channel(self):
         """Establish a connection to the Broker for the offsets channel"""
         conn = BrokerConnection(self.host, self.port, self._buffer_size)
-        conn.connect(self._timeout)
+        conn.connect(self._offsets_channel_socket_timeout_ms)
         self._offsets_channel_req_handler = RequestHandler(self._handler, conn)
         self._offsets_channel_req_handler.start()
         self._offsets_channel_connected = True

--- a/kafka/pykafka/broker.py
+++ b/kafka/pykafka/broker.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 class Broker(base.BaseBroker):
 
-    def __init__(self, id_, host, port, handler, timeout):
+    def __init__(self, id_, host, port, handler, timeout,
+                 buffer_size=64 * 1024):
         """Init a Broker.
 
         :param handler: TODO: Fill in
@@ -31,17 +32,20 @@ class Broker(base.BaseBroker):
         self._handler = handler
         self._reqhandler = None
         self._timeout = timeout
+        self._buffer_size = buffer_size
         self.connect()
 
     @classmethod
-    def from_metadata(cls, metadata, handler, timeout):
+    def from_metadata(cls, metadata, handler, timeout,
+                      buffer_size=64 * 1024):
         """ Create a Broker using BrokerMetadata
 
         :param metadata: Metadata that describes the broker.
         :type metadata: :class:`kafka.pykafka.protocol.BrokerMetadata.`
         """
         return cls(metadata.id, metadata.host,
-                   metadata.port, handler, timeout)
+                   metadata.port, handler, timeout,
+                   buffer_size=buffer_size)
 
     @property
     def connected(self):
@@ -70,7 +74,7 @@ class Broker(base.BaseBroker):
 
     def connect(self):
         """Establish a connection to the Broker."""
-        conn = BrokerConnection(self.host, self.port)
+        conn = BrokerConnection(self.host, self.port, self._buffer_size)
         conn.connect(self._timeout)
         self._reqhandler = RequestHandler(self._handler, conn)
         self._reqhandler.start()

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -16,11 +16,13 @@ class Cluster(object):
     def __init__(self,
                  hosts,
                  handler,
-                 timeout,
+                 socket_timeout_ms=30 * 1000,
+                 offsets_channel_socket_timeout_ms=10 * 1000,
                  socket_receive_buffer_bytes=64 * 1024,
                  exclude_internal_topics=True):
         self._seed_hosts = hosts
-        self._timeout = timeout
+        self._socket_timeout_ms = socket_timeout_ms
+        self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._handler = handler
         self._brokers = {}
         self._topics = {}
@@ -52,7 +54,8 @@ class Cluster(object):
             try:
                 if isinstance(broker, basestring):
                     h, p = broker.split(':')
-                    broker = Broker(-1, h, p, self._handler, self._timeout,
+                    broker = Broker(-1, h, p, self._handler, self._socket_timeout_ms,
+                                    self._offsets_channel_socket_timeout_ms,
                                     buffer_size=self._socket_receive_buffer_bytes)
                 return broker.request_metadata()
             # TODO: Change to typed exception
@@ -79,7 +82,8 @@ class Cluster(object):
             if id_ not in self._brokers:
                 logger.info('Discovered broker %s:%s', meta.host, meta.port)
                 self._brokers[id_] = Broker.from_metadata(
-                    meta, self._handler, self._timeout,
+                    meta, self._handler, self._socket_timeout_ms,
+                    self._offsets_channel_socket_timeout_ms,
                     buffer_size=self._socket_receive_buffer_bytes
                 )
             else:

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -2,8 +2,6 @@ import logging
 import time
 import random
 
-from kazoo.client import KazooClient
-
 from .broker import Broker
 from .topic import Topic
 from .protocol import ConsumerMetadataRequest, ConsumerMetadataResponse
@@ -15,20 +13,13 @@ logger = logging.getLogger(__name__)
 class Cluster(object):
     """Cluster implementation used to populate the KafkaClient."""
 
-    def __init__(self, hosts, zk_host, handler, timeout):
+    def __init__(self, hosts, handler, timeout):
         self._seed_hosts = hosts
         self._timeout = timeout
         self._handler = handler
         self._brokers = {}
         self._topics = {}
-        zookeeper = KazooClient(zk_host)
-        zookeeper.start()
-        self._zookeeper = zookeeper
         self.update()
-
-    @property
-    def zookeeper(self):
-        return self._zookeeper
 
     @property
     def brokers(self):

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -74,7 +74,7 @@ class Cluster(object):
         # Add/update current brokers
         for id_, meta in broker_metadata.iteritems():
             if id_ not in self._brokers:
-                logger.info('Adding new broker %s:%s', meta.host, meta.port)
+                logger.info('Discovered broker %s:%s', meta.host, meta.port)
                 self._brokers[id_] = Broker.from_metadata(
                     meta, self._handler, self._timeout,
                     buffer_size=self._socket_receive_buffer_bytes
@@ -105,7 +105,7 @@ class Cluster(object):
             if not self._should_exclude_topic(name):
                 if name not in self._topics:
                     self._topics[name] = Topic(self, meta)
-                    logger.info('Adding topic %s', self._topics[name])
+                    logger.info('Discovered topic %s', self._topics[name])
                 else:
                     self._topics[name].update(meta)
 

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -2,6 +2,8 @@ import logging
 import time
 import random
 
+from kazoo.client import KazooClient
+
 from .broker import Broker
 from .topic import Topic
 from .protocol import ConsumerMetadataRequest, ConsumerMetadataResponse
@@ -13,13 +15,20 @@ logger = logging.getLogger(__name__)
 class Cluster(object):
     """Cluster implementation used to populate the KafkaClient."""
 
-    def __init__(self, hosts, handler, timeout):
+    def __init__(self, hosts, zk_host, handler, timeout):
         self._seed_hosts = hosts
         self._timeout = timeout
         self._handler = handler
         self._brokers = {}
         self._topics = {}
+        zookeeper = KazooClient(zk_host)
+        zookeeper.start()
+        self._zookeeper = zookeeper
         self.update()
+
+    @property
+    def zookeeper(self):
+        return self._zookeeper
 
     @property
     def brokers(self):

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -101,7 +101,7 @@ class Cluster(object):
         # Add/update partition information
         for name, meta in metadata.iteritems():
             if name not in self._topics:
-                self._topics[name] = Topic(self._brokers, meta)
+                self._topics[name] = Topic(self, meta)
                 logger.info('Adding topic %s', self._topics[name])
             else:
                 self._topics[name].update(meta)

--- a/kafka/pykafka/cluster.py
+++ b/kafka/pykafka/cluster.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 class Cluster(object):
     """Cluster implementation used to populate the KafkaClient."""
 
-    def __init__(self, hosts, handler, timeout,
+    def __init__(self,
+                 hosts,
+                 handler,
+                 timeout,
                  socket_receive_buffer_bytes=64 * 1024,
                  exclude_internal_topics=True):
         self._seed_hosts = hosts

--- a/kafka/pykafka/connection.py
+++ b/kafka/pykafka/connection.py
@@ -76,8 +76,7 @@ class BrokerConnection(object):
             size = self._socket.recv(4)
             size = struct.unpack('!i', size)[0]
             recvall_into(self._socket, self._buff, size)
-            # TODO: Figure out if correlation ids are worth it
-            return buffer(self._buff[4:4 + size]) # skipping it for now
+            return buffer(self._buff[4:4 + size])
         except SocketDisconnectedError:
             self.disconnect()
             raise

--- a/kafka/pykafka/connection.py
+++ b/kafka/pykafka/connection.py
@@ -31,6 +31,7 @@ class BrokerConnection(object):
     """A socket connection to Kafka."""
 
     def __init__(self, host, port):
+        self._buff = bytearray(64 * 1024)
         self.host = host
         self.port = port
         self._socket = None
@@ -74,10 +75,9 @@ class BrokerConnection(object):
         try:
             size = self._socket.recv(4)
             size = struct.unpack('!i', size)[0]
-            output = bytearray(size)
-            recvall_into(self._socket, output)
+            recvall_into(self._socket, self._buff, size)
             # TODO: Figure out if correlation ids are worth it
-            return buffer(output[4:]) # skipping it for now
+            return buffer(self._buff[4:4 + size]) # skipping it for now
         except SocketDisconnectedError:
             self.disconnect()
             raise

--- a/kafka/pykafka/connection.py
+++ b/kafka/pykafka/connection.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 __license__ = """
 Copyright 2012 DISQUS
 Copyright 2013,2014 Parse.ly, Inc.
@@ -48,7 +50,7 @@ class BrokerConnection(object):
         """Connect to the broker."""
         self._socket = socket.create_connection(
             (self.host, self.port),
-            timeout=float(timeout) / 1000.0
+            timeout=timeout / 1000
         )
 
     def disconnect(self):

--- a/kafka/pykafka/connection.py
+++ b/kafka/pykafka/connection.py
@@ -30,8 +30,8 @@ logger = logging.getLogger(__name__)
 class BrokerConnection(object):
     """A socket connection to Kafka."""
 
-    def __init__(self, host, port):
-        self._buff = bytearray(64 * 1024)
+    def __init__(self, host, port, buffer_size=64 * 1024):
+        self._buff = bytearray(buffer_size)
         self.host = host
         self.port = port
         self._socket = None

--- a/kafka/pykafka/connection.py
+++ b/kafka/pykafka/connection.py
@@ -48,7 +48,7 @@ class BrokerConnection(object):
         """Connect to the broker."""
         self._socket = socket.create_connection(
             (self.host, self.port),
-            timeout=timeout
+            timeout=float(timeout) / 1000.0
         )
 
     def disconnect(self):

--- a/kafka/pykafka/partition.py
+++ b/kafka/pykafka/partition.py
@@ -67,7 +67,7 @@ class Partition(base.BasePartition):
         request = PartitionOffsetRequest(
             self.topic.name, self.id, offsets_before, max_offsets
         )
-        res = self.leader.request_offsets([request])
+        res = self._leader.request_offsets([request])
         return res.topics[self.topic.name][self._id][0]
 
     def latest_available_offsets(self):
@@ -97,9 +97,9 @@ class Partition(base.BasePartition):
         """
         try:
             # Check leader
-            if metadata.leader != self.leader.id:
+            if metadata.leader != self._leader.id:
                 logger.info('Updating leader for %s', self)
-                self.leader = brokers[metadata.leader]
+                self._leader = brokers[metadata.leader]
             # Check Replicas
             if sorted(r.id for r in self.replicas) != sorted(metadata.replicas):
                 logger.info('Updating replicas list for %s', self)

--- a/kafka/pykafka/protocol.py
+++ b/kafka/pykafka/protocol.py
@@ -51,12 +51,11 @@ from zlib import crc32
 
 from kafka import common
 from kafka.common import CompressionType
-from kafka.exceptions import ERROR_CODES
+from kafka.exceptions import ERROR_CODES, OffsetOutOfRangeError
 from .utils import Serializable, compression, struct_helpers
 
 
 logger = logging.getLogger(__name__)
-ERROR_OFFSET_OUT_OF_RANGE = 1
 
 
 class Request(Serializable):
@@ -640,7 +639,7 @@ class FetchResponse(Response):
         self.topics = defaultdict(dict)
         for (topic, partitions) in response:
             for partition in partitions:
-                if partition[1] not in (0, 1):
+                if partition[1] not in (0, OffsetOutOfRangeError.ERROR_CODE):
                     self.raise_error(partition[1], response)
                 self.topics[topic][partition[0]] = FetchPartitionResponse(
                     partition[2], self._unpack_message_set(partition[3]),
@@ -1081,7 +1080,7 @@ class OffsetFetchResponse(Response):
         for topic_name, partitions in response:
             self.topics[topic_name] = {}
             for partition in partitions:
-                if partition[3] not in (0, ERROR_OFFSET_OUT_OF_RANGE):
+                if partition[3] not in (0, OffsetOutOfRangeError.ERROR_CODE):
                     self.raise_error(partition[3], response)
                 pres = OffsetFetchPartitionResponse(partition[1],
                                                     partition[2],

--- a/kafka/pykafka/protocol.py
+++ b/kafka/pykafka/protocol.py
@@ -56,6 +56,7 @@ from .utils import Serializable, compression, struct_helpers
 
 
 logger = logging.getLogger(__name__)
+ERROR_OFFSET_OUT_OF_RANGE = 1
 
 
 class Request(Serializable):
@@ -1044,7 +1045,7 @@ class OffsetFetchRequest(Request):
 
 class OffsetFetchPartitionResponse(object):
     """Partition information that's part of an OffsetFetchResponse"""
-    def __init__(self, offset, metadata):
+    def __init__(self, offset, metadata, error):
         """Create a new OffsetFetchPartitionResponse
 
         :param offset:
@@ -1052,6 +1053,7 @@ class OffsetFetchPartitionResponse(object):
         """
         self.offset = offset
         self.metadata = metadata
+        self.error = error
 
 
 class OffsetFetchResponse(Response):
@@ -1077,7 +1079,9 @@ class OffsetFetchResponse(Response):
         for topic_name, partitions in response:
             self.topics[topic_name] = {}
             for partition in partitions:
-                if partition[3] != 0:
+                if partition[3] not in (0, ERROR_OFFSET_OUT_OF_RANGE):
                     self.raise_error(partition[3], response)
-                pres = OffsetFetchPartitionResponse(partition[1], partition[2])
+                pres = OffsetFetchPartitionResponse(partition[1],
+                                                    partition[2],
+                                                    partition[3])
                 self.topics[topic_name][partition[0]] = pres

--- a/kafka/pykafka/protocol.py
+++ b/kafka/pykafka/protocol.py
@@ -608,7 +608,7 @@ class FetchRequest(Request):
 
 class FetchPartitionResponse(object):
     """Partition information that's part of a FetchResponse"""
-    def __init__(self, max_offset, messages):
+    def __init__(self, max_offset, messages, error):
         """Create a new FetchPartitionResponse
 
         :param max_offset: The offset at the end of this partition
@@ -616,6 +616,7 @@ class FetchPartitionResponse(object):
         """
         self.max_offset = max_offset
         self.messages = messages
+        self.error = error
 
 
 class FetchResponse(Response):
@@ -639,10 +640,11 @@ class FetchResponse(Response):
         self.topics = defaultdict(dict)
         for (topic, partitions) in response:
             for partition in partitions:
-                if partition[1] != 0:
+                if partition[1] not in (0, 1):
                     self.raise_error(partition[1], response)
                 self.topics[topic][partition[0]] = FetchPartitionResponse(
                     partition[2], self._unpack_message_set(partition[3]),
+                    partition[1]
                 )
 
     def _unpack_message_set(self, buff):

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -102,9 +102,9 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         self._queued_max_messages = queued_max_messages
         self._num_consumer_fetchers = num_consumer_fetchers
         self._fetch_wait_max_ms = fetch_wait_max_ms
+        self._consumer_timeout_ms = consumer_timeout_ms
 
         self._last_message_time = time.time()
-        self._consumer_timeout_ms = consumer_timeout_ms
 
         self._auto_commit_enable = auto_commit_enable
         self._auto_commit_interval_ms = auto_commit_interval_ms

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -104,8 +104,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         self._auto_commit_interval_ms = auto_commit_interval_ms
         self._last_auto_commit = time.time()
 
-        self._running = True
-
         self._offset_manager = self._cluster.get_offset_manager(self._consumer_group)
 
         owned_partition_partial = functools.partial(
@@ -123,6 +121,8 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         for p in self._partitions.iterkeys():
             self._partitions_by_leader[p.partition.leader].append(p)
         self.partition_cycle = itertools.cycle(self._partitions.keys())
+
+        self._running = True
 
         if self._auto_commit_enable:
             self._autocommit_worker_thread = self._setup_autocommit_worker()

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import time
 import logging as log
 from Queue import Queue, Empty
+import weakref
 
 from kafka import base
 from kafka.common import OffsetType
@@ -92,7 +93,10 @@ class SimpleConsumer(base.BaseSimpleConsumer):
             if no message is available for consumption after the specified interval
         :type consumer_timeout_ms: int
         """
-        self._cluster = cluster
+        if not isinstance(cluster, weakref.ProxyType):
+            self._cluster = weakref.proxy(cluster)
+        else:
+            self._cluster = cluster
         self._consumer_group = consumer_group
         self._topic = topic
         self._fetch_message_max_bytes = fetch_message_max_bytes

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -29,7 +29,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
                  fetch_wait_max_ms=100,
                  refresh_leader_backoff_ms=200,
                  offsets_channel_backoff_ms=1000,
-                 offsets_channel_socket_timeout_ms=10000,
                  offsets_commit_max_retries=5,
                  auto_offset_reset=OffsetType.LATEST,
                  consumer_timeout_ms=-1):
@@ -77,11 +76,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :param offsets_channel_backoff_ms: backoff time to retry offset
             commits/fetches
         :type offsets_channel_backoff_ms: int
-        :param offsets_channel_socket_timeout_ms: socket timeout to use when
-            reading responses for Offset Fetch/Commit requests. This timeout
-            will also be used for the ConsumerMetdata requests that are used
-            to query for the offset coordinator.
-        :type offsets_channel_socket_timeout_ms: int
         :param offsets_commit_max_retries: Retry the offset commit up to this
             many times on failure.
         :type offsets_commit_max_retries: int

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -8,19 +8,11 @@ from Queue import Queue, Empty
 from kafka import base
 from kafka.common import OffsetType
 
-from .protocol import (PartitionFetchRequest,
-                       PartitionOffsetCommitRequest,
+from .protocol import (PartitionFetchRequest, PartitionOffsetCommitRequest,
                        PartitionOffsetFetchRequest)
-
-# Settings to add to the eventual BalancedConsumer
-# consumer_group
-# rebalance_max_retries
-# rebalance_backoff_ms
-# partition_assignment_strategy
 
 
 class SimpleConsumer(base.BaseSimpleConsumer):
-
     def __init__(self,
                  topic,
                  cluster,

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -241,10 +241,10 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         for broker, owned_partitions in self._partitions_by_leader.iteritems():
             reqs = []
             for owned_partition in owned_partitions:
-                # attempt to acquire lock, just pass if we can't
-                if owned_partition.lock.acquire(False):
-                    has_room = owned_partition.message_count < self._queued_max_messages
-                    if owned_partition.empty and has_room:
+                has_room = owned_partition.message_count < self._queued_max_messages
+                if owned_partition.empty and has_room:
+                    # attempt to acquire lock, just pass if we can't
+                    if owned_partition.lock.acquire(False):
                         reqs.append(owned_partition.build_fetch_request(
                             self._fetch_message_max_bytes))
             if reqs:

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -51,6 +51,8 @@ class SimpleConsumer(base.BaseSimpleConsumer):
 
         :param topic: the topic this consumer should consume
         :type topic: pykafka.topic.Topic
+        :param cluster: the cluster this consumer should connect to
+        :type cluster: pykafka.cluster.Cluster
         :param consumer_group: the name of the consumer group to join
         :type consumer_group: str
         :param partitions: existing partitions to which to connect

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -9,10 +9,10 @@ import threading
 
 from kafka import base
 from kafka.common import OffsetType
+from kafka.exceptions import OffsetOutOfRangeError
 
 from .protocol import (PartitionFetchRequest, PartitionOffsetCommitRequest,
-                       PartitionOffsetFetchRequest, ERROR_OFFSET_OUT_OF_RANGE,
-                       PartitionOffsetRequest)
+                       PartitionOffsetFetchRequest, PartitionOffsetRequest)
 
 
 class SimpleConsumer(base.BaseSimpleConsumer):
@@ -257,7 +257,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         out_of_range_partitions, in_range_partitions = [], []
         for partition_id, pres in res.topics[self._topic.name].iteritems():
             owned_partition = self._partitions_by_id[partition_id]
-            if pres.error == ERROR_OFFSET_OUT_OF_RANGE:
+            if pres.error == OffsetOutOfRangeError.ERROR_CODE:
                 out_of_range_partitions.append(owned_partition)
             else:
                 in_range_partitions.append((owned_partition, pres))

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -305,7 +305,7 @@ class OwnedPartition(object):
             self.partition.id,
             self.last_offset_consumed,
             int(time.time()),
-            ''  # TODO - what to do with metadata?
+            'pykafka'
         )
 
     def build_offset_fetch_request(self):

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -110,6 +110,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         self._fetch_message_max_bytes = fetch_message_max_bytes
         self._socket_timeout_ms = socket_timeout_ms
         self._fetch_min_bytes = fetch_min_bytes
+        self._queued_max_messages = queued_max_messages
 
         self._last_message_time = time.time()
         self._consumer_timeout_ms = consumer_timeout_ms
@@ -119,8 +120,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         self._last_auto_commit = time.time()
 
         self._running = True
-
-        self._queued_max_messages = queued_max_messages
 
         self._offset_manager = self._cluster.get_offset_manager(self._consumer_group)
 

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -153,7 +153,9 @@ class SimpleConsumer(base.BaseSimpleConsumer):
     def _setup_autocommit_worker(self):
         def autocommitter():
             while True:
-                if self._running and self._auto_commit_enable:
+                if not self._running:
+                    break
+                if self._auto_commit_enable:
                     self._auto_commit()
         log.debug("Starting autocommitter thread")
         return self._cluster.handler.spawn(autocommitter)
@@ -161,8 +163,9 @@ class SimpleConsumer(base.BaseSimpleConsumer):
     def _setup_fetch_workers(self):
         def fetcher():
             while True:
-                if self._running:
-                    self.fetch()
+                if not self._running:
+                    break
+                self.fetch()
         return [self._cluster.handler.spawn(fetcher)
                 for i in xrange(self._num_consumer_fetchers)]
 

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -241,8 +241,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         for broker, owned_partitions in self._partitions_by_leader.iteritems():
             reqs = []
             for owned_partition in owned_partitions:
-                has_room = owned_partition.message_count < self._queued_max_messages
-                if owned_partition.empty and has_room:
+                if owned_partition.message_count < self._queued_max_messages:
                     # attempt to acquire lock, just pass if we can't
                     if owned_partition.lock.acquire(False):
                         reqs.append(owned_partition.build_fetch_request(
@@ -276,10 +275,6 @@ class OwnedPartition(object):
     @property
     def message_count(self):
         return self._messages.qsize()
-
-    @property
-    def empty(self):
-        return self._messages.empty()
 
     def set_offset_counters(self, res):
         """Set the internal offset counters from an OffsetFetchResponse

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -19,7 +19,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
                  consumer_group=None,
                  partitions=None,
                  socket_timeout_ms=30 * 1000,
-                 socket_receive_buffer_bytes=60 * 1024,
                  fetch_message_max_bytes=1024 * 1024,
                  num_consumer_fetchers=1,
                  auto_commit_enable=False,
@@ -51,9 +50,6 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :type partitions: list of pykafka.partition.Partition
         :param socket_timeout_ms: the socket timeout for network requests
         :type socket_timeout_ms: int
-        :param socket_receive_buffer_bytes: the size of the socket receive
-            buffer for network requests
-        :type socket_receive_buffer_bytes: int
         :param fetch_message_max_bytes: the number of bytes of messages to
             attempt to fetch
         :type fetch_message_max_bytes: int

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -98,10 +98,10 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         self._consumer_group = consumer_group
         self._topic = topic
         self._fetch_message_max_bytes = fetch_message_max_bytes
-        self._socket_timeout_ms = socket_timeout_ms
         self._fetch_min_bytes = fetch_min_bytes
         self._queued_max_messages = queued_max_messages
         self._num_consumer_fetchers = num_consumer_fetchers
+        self._fetch_wait_max_ms = fetch_wait_max_ms
 
         self._last_message_time = time.time()
         self._consumer_timeout_ms = consumer_timeout_ms
@@ -252,7 +252,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
                             self._fetch_message_max_bytes))
             if reqs:
                 response = broker.fetch_messages(
-                    reqs, timeout=self._socket_timeout_ms,
+                    reqs, timeout=self._fetch_wait_max_ms,
                     min_bytes=self._fetch_min_bytes
                 )
                 for partition_id, pres in response.topics[self._topic.name].iteritems():

--- a/kafka/pykafka/simpleconsumer.py
+++ b/kafka/pykafka/simpleconsumer.py
@@ -18,7 +18,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
                  cluster,
                  consumer_group=None,
                  partitions=None,
-                 socket_timeout_ms=30000,
+                 socket_timeout_ms=30 * 1000,
                  socket_receive_buffer_bytes=60 * 1024,
                  fetch_message_max_bytes=1024 * 1024,
                  num_consumer_fetchers=1,

--- a/kafka/pykafka/topic.py
+++ b/kafka/pykafka/topic.py
@@ -101,16 +101,13 @@ class Topic(base.BaseTopic):
             else:
                 self._partitions[id_].update(meta)
 
-    def get_simple_consumer(self, consumer_group, **kwargs):
+    def get_simple_consumer(self, consumer_group=None, **kwargs):
         """Return a SimpleConsumer of this topic
         """
         return SimpleConsumer(self, self._cluster,
-                              consumer_group=consumer_group,
-                              **kwargs)
+                              consumer_group=consumer_group, **kwargs)
 
     def get_balanced_consumer(self, consumer_group, **kwargs):
         """Return a BalancedConsumer of this topic
         """
-        return BalancedConsumer(self, self._cluster,
-                                consumer_group=consumer_group,
-                                **kwargs)
+        return BalancedConsumer(self, self._cluster, consumer_group, **kwargs)

--- a/kafka/pykafka/topic.py
+++ b/kafka/pykafka/topic.py
@@ -100,3 +100,17 @@ class Topic(base.BaseTopic):
                 )
             else:
                 self._partitions[id_].update(meta)
+
+    def get_simple_consumer(self, consumer_group, **kwargs):
+        """Return a SimpleConsumer of this topic
+        """
+        return SimpleConsumer(self, self._cluster,
+                              consumer_group=consumer_group,
+                              **kwargs)
+
+    def get_balanced_consumer(self, consumer_group, **kwargs):
+        """Return a BalancedConsumer of this topic
+        """
+        return BalancedConsumer(self, self._cluster,
+                                consumer_group=consumer_group,
+                                **kwargs)

--- a/kafka/pykafka/topic.py
+++ b/kafka/pykafka/topic.py
@@ -2,14 +2,17 @@
 # TODO: __slots__ where appropriate
 # TODO: Use weak refs to avoid reference cycles?
 
-import logging
 from collections import defaultdict
+import logging
+import weakref
 
 from kafka import base
 from kafka.common import OffsetType
 from .partition import Partition
 from .producer import Producer
 from .protocol import PartitionOffsetRequest
+from .simpleconsumer import SimpleConsumer
+from .balancedconsumer import BalancedConsumer
 
 
 logger = logging.getLogger()
@@ -17,15 +20,16 @@ logger = logging.getLogger()
 
 class Topic(base.BaseTopic):
 
-    def __init__(self, brokers, topic_metadata):
+    def __init__(self, cluster, topic_metadata):
         """Create the Topic from metadata.
 
         :param topic_metadata: Metadata for all topics
         :type topic_metadata: :class:`kafka.pykafka.protocol.TopicMetadata`
         """
         self._name = topic_metadata.name
+        self._cluster = weakref.proxy(cluster)
         self._partitions = {}
-        self.update(brokers, topic_metadata)
+        self.update(cluster.brokers, topic_metadata)
 
     @property
     def name(self):

--- a/kafka/pykafka/utils/socket.py
+++ b/kafka/pykafka/utils/socket.py
@@ -17,9 +17,9 @@ limitations under the License.
 from kafka.exceptions import SocketDisconnectedError
 
 
-def recvall_into(socket, bytea):
+def recvall_into(socket, bytea, size):
     """
-    Reads enough data from the socket to fill the provided bytearray (modifies
+    Reads `size` bytes from the socket into the provided bytearray (modifies
     in-place.)
 
     This is basically a hack around the fact that ``socket.recv_into`` doesn't
@@ -27,10 +27,10 @@ def recvall_into(socket, bytea):
 
     :type socket: :class:`socket.Socket`
     :type bytea: ``bytearray``
+    :type size: int
     :rtype: ``bytearray``
     """
     offset = 0
-    size = len(bytea)
     while offset < size:
         remaining = size - offset
         chunk = socket.recv(remaining)

--- a/kafka/pykafka/utils/socket.py
+++ b/kafka/pykafka/utils/socket.py
@@ -31,6 +31,8 @@ def recvall_into(socket, bytea, size):
     :rtype: ``bytearray``
     """
     offset = 0
+    if size > len(bytea):
+        raise ValueError("Buffer overflow in broker connection (buffer size is {})".format(len(bytea)))
     while offset < size:
         remaining = size - offset
         chunk = socket.recv(remaining)


### PR DESCRIPTION
This pull request adds a `BalancedConsumer` to pykafka. Related to [this issue](https://github.com/Parsely/pykafka/issues/116).

Since the minute details of actual message consumption are handled in `SimpleConsumer`, and since the `BalancedConsumer` maintains its own instance of one, the `BalancedConsumer` class essentially amounts to a 250+ line implementation of the consumer rebalancing algorithm detailed [here](http://kafka.apache.org/documentation.html).

Currently, this is the only piece of pykafka that uses a `KazooClient`.

# Major changes
* Implements `BalancedConsumer`
* Adds some configuration parameters to `SimpleConsumer`
* Makes messages fetching thread-safe in the `SimpleConsumer`
* Uses a single buffer allocation for kafka api responses
* Adds convenience methods to `Topic` for creating consumers
* Adds a few configuration parameters to `Cluster`
* Maintains a second socket connection for CF API communication
* Implements automatic offset resetting in the `SimpleConsumer`

# Todo
* [x] To properly support the `offsets.channel` config options, `Broker` should maintain two connections: one for non-offset-related requests and one for offset-related requests. This will allow the socket timeout to be configurable for commit requests independently of the timeout for other requests.
* [x] Support other remaining configuration options