### PR TITLE
Handle errors in consumer

### DIFF
--- a/pykafka/pykafka/broker.py
+++ b/pykafka/pykafka/broker.py
@@ -187,7 +187,7 @@ class Broker(base.BaseBroker):
                                   consumer_group_generation_id,
                                   consumer_id,
                                   partition_requests=preqs)
-        self._offsets_channel_req_handler.request(req).get(OffsetCommitResponse)
+        return self._offsets_channel_req_handler.request(req).get(OffsetCommitResponse)
 
     def fetch_consumer_group_offsets(self, consumer_group, preqs):
         """Fetch the offsets stored in Kafka with the Offset Commit/Fetch API

--- a/pykafka/pykafka/protocol.py
+++ b/pykafka/pykafka/protocol.py
@@ -101,6 +101,11 @@ class Response(object):
                 clsname, response))
 
 
+class PartitionResponse(object):
+    def __init__(self, error):
+        self.error = error
+
+
 class Message(common.Message, Serializable):
     """Representation of a Kafka Message
 
@@ -605,7 +610,7 @@ class FetchRequest(Request):
         return output
 
 
-class FetchPartitionResponse(object):
+class FetchPartitionResponse(PartitionResponse):
     """Partition information that's part of a FetchResponse"""
     def __init__(self, max_offset, messages, error):
         """Create a new FetchPartitionResponse
@@ -613,9 +618,9 @@ class FetchPartitionResponse(object):
         :param max_offset: The offset at the end of this partition
         :param messages: Messages in the response
         """
+        super(FetchPartitionResponse, self).__init__(error)
         self.max_offset = max_offset
         self.messages = messages
-        self.error = error
 
 
 class FetchResponse(Response):
@@ -739,6 +744,18 @@ class OffsetRequest(Request):
                                  pnum, offsets_before, max_offsets)
                 offset += 16
         return output
+
+
+class OffsetPartitionResponse(PartitionResponse):
+    """Partition information that's part of an OffsetResponse"""
+    def __init__(self, offset, error):
+        """Create a new OffsetPartitionResponse
+
+        :param offset: The requested offset
+        :param error: The error code
+        """
+        super(OffsetPartitionResponse, self).__init__(error)
+        self.offset = offset
 
 
 class OffsetResponse(Response):
@@ -937,6 +954,16 @@ class OffsetCommitRequest(Request):
         return output
 
 
+class OffsetCommitPartitionResponse(PartitionResponse):
+    """Partition information that's part of an OffsetCommitResponse"""
+    def __init__(self, error):
+        """Create a new OffsetCommitPartitionResponse
+
+        :param error: The error code for this partition
+        """
+        super(OffsetCommitPartitionResponse, self).__init__(error)
+
+
 class OffsetCommitResponse(Response):
     """An offset commit response
 
@@ -1042,7 +1069,7 @@ class OffsetFetchRequest(Request):
         return output
 
 
-class OffsetFetchPartitionResponse(object):
+class OffsetFetchPartitionResponse(PartitionResponse):
     """Partition information that's part of an OffsetFetchResponse"""
     def __init__(self, offset, metadata, error):
         """Create a new OffsetFetchPartitionResponse
@@ -1050,9 +1077,9 @@ class OffsetFetchPartitionResponse(object):
         :param offset:
         :param metadata: arbitrary metadata that should be committed with this offset commit
         """
+        super(OffsetFetchPartitionResponse, self).__init__(error)
         self.offset = offset
         self.metadata = metadata
-        self.error = error
 
 
 class OffsetFetchResponse(Response):

--- a/pykafka/pykafka/protocol.py
+++ b/pykafka/pykafka/protocol.py
@@ -780,9 +780,8 @@ class OffsetResponse(Response):
         for topic_name, partitions in response:
             self.topics[topic_name] = {}
             for partition in partitions:
-                if partition[1] != 0:
-                    self.raise_error(partition[1], response)
-                self.topics[topic_name][partition[0]] = partition[2]
+                self.topics[topic_name][partition[0]] = OffsetPartitionResponse(
+                    partition[2], partition[1])
 
 
 class ConsumerMetadataRequest(Request):
@@ -983,13 +982,9 @@ class OffsetCommitResponse(Response):
 
         self.topics = {}
         for topic_name, partitions in response:
-            # a list makes sense here instead of a dict since the only returned
-            # information about the partition is the name
-            self.topics[topic_name] = []
+            self.topics[topic_name] = {}
             for partition in partitions:
-                if partition[1] != 0:
-                    self.raise_error(partition[1], response)
-                self.topics[topic_name].append(partition[0])
+                self.topics[topic_name][partition[0]] = OffsetCommitPartitionResponse(partition[1])
 
 
 _PartitionOffsetFetchRequest = namedtuple(

--- a/pykafka/pykafka/simpleconsumer.py
+++ b/pykafka/pykafka/simpleconsumer.py
@@ -265,7 +265,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
                 partitions_by_error[pres.error].append((owned_partition, pres))
         return partitions_by_error
 
-    def _handle_partition_errors(self, response, success_handler=None, error_handlers=None):
+    def _handle_partition_errors(self, response, success_handler=None, handlers=None):
         """Call the appropriate handler for each errored partition
 
         :param response: a Response object containing partition responses
@@ -275,10 +275,10 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :param error_handlers: mapping of error code to handler
         :type error_handlers: dict {int: callable(owned_partition, partition_response)}
         """
-        if error_handlers is None:
-            error_handlers = {}
-        error_handlers = dict(
-            self._default_error_handlers.items() + error_handlers.items())
+        if handlers is None:
+            handlers = {}
+        error_handlers = self._default_error_handlers.clone()
+        error_handlers.update(handlers.items())
         if success_handler is not None:
             error_handlers[0] = success_handler
 

--- a/pykafka/pykafka/simpleconsumer.py
+++ b/pykafka/pykafka/simpleconsumer.py
@@ -305,12 +305,12 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :type errored_partitions: Iterable of OwnedPartition
         """
         # group out-of-range partitions by leader
-        owned_partitions_by_leader = defaultdict(list)
+        by_leader = defaultdict(list)
         for p in errored_partitions:
-            owned_partitions_by_leader[p.partition.leader].append(p)
+            by_leader[p.partition.leader].append(p)
 
         # get valid offset ranges for each partition
-        for broker, owned_partitions in owned_partitions_by_leader.iteritems():
+        for broker, owned_partitions in by_leader.iteritems():
             reqs = [owned_partition.build_offset_request(self._auto_offset_reset)
                     for owned_partition in owned_partitions]
             response = broker.request_offset_limits(reqs)

--- a/pykafka/pykafka/simpleconsumer.py
+++ b/pykafka/pykafka/simpleconsumer.py
@@ -285,9 +285,9 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :param response: a Response object containing partition responses
         :type response: pykafka.protocol.Response
         :param success_handler: function to call for successful partitions
-        :type success_handler: callable(owned_partition, partition_response)
+        :type success_handler: callable(parts)
         :param error_handlers: mapping of error code to handler
-        :type error_handlers: dict {int: callable(owned_partition, partition_response)}
+        :type error_handlers: dict {int: callable(parts)}
         """
         if handlers is None:
             handlers = {}

--- a/pykafka/pykafka/utils/error_handlers.py
+++ b/pykafka/pykafka/utils/error_handlers.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+
+def handle_partition_responses(response,
+                               error_handlers,
+                               success_handler=None,
+                               partitions_by_id=None):
+    """Call the appropriate handler for each errored partition
+
+    :param response: a Response object containing partition responses
+    :type response: pykafka.protocol.Response
+    :param success_handler: function to call for successful partitions
+    :type success_handler: callable(parts)
+    :param error_handlers: mapping of error code to handler
+    :type error_handlers: dict {int: callable(parts)}
+    :param partitions_by_id: a dict mapping partition ids to OwnedPartition
+        instances
+    :type partitions_by_id: dict {int: pykafka.simpleconsumer.OwnedPartition}
+    """
+    error_handlers = error_handlers.copy()
+    if success_handler is not None:
+        error_handlers[0] = success_handler
+
+    # group partition responses by error code
+    parts_by_error = defaultdict(list)
+    for topic_name in response.topics.keys():
+        for partition_id, pres in response.topics[topic_name].iteritems():
+            owned_partition = None
+            if partitions_by_id is not None:
+                owned_partition = partitions_by_id[partition_id]
+            parts_by_error[pres.error].append((owned_partition, pres))
+
+    for errcode, parts in parts_by_error.iteritems():
+        if errcode in error_handlers:
+            error_handlers[errcode](parts)
+
+    return parts_by_error


### PR DESCRIPTION
Related to https://github.com/Parsely/pykafka/issues/110

# Error Checklist
Some of these may be unnecessary, remove or comment if that's the case
- [x] Consumer OffsetOutOfRange
- [ ] Consumer InvalidMessage
- [x] Consumer UnknownTopicOrPartition
- [ ] Consumer InvalidMessageSize
- [ ] Consumer LeaderNotAvailable
- [ ] Consumer NotLeaderForPartition
- [ ] Consumer RequestTimedOut
- [ ] Consumer BrokerNotAvailable
- [ ] Consumer ReplicaNotAvailable
- [ ] Consumer MessageSizeTooLarge
- [ ] Consumer StaleControllerEpochCode
- [ ] Consumer OffsetMetadataTooLargeCode
- [ ] Consumer OffsetsLoadInProgressCode
- [ ] Consumer ConsumerCoordinatorNotAvailableCode
- [ ] Consumer NotCoordinatorForConsumerCode