### PR TITLE
utils.socket: avoid overflow exceptions (fixes #151)

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -99,4 +99,4 @@ class BrokerConnection(object):
         size = struct.unpack('!i', size)[0]
         output = bytearray(size)
         recvall_into(self._socket, output, self._buffer_size)
-        return memoryview(output)[4:]  # skip past correlation-id
+        return buffer(output)[4:]  # skip past correlation-id

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -45,10 +45,10 @@ class BrokerConnection(object):
             hold response data.
         :type buffer_size: int
         """
-        self._buff = bytearray(buffer_size)
         self.host = host
         self.port = port
         self._socket = None
+        self._buffer_size = buffer_size
 
     def __del__(self):
         """Close this connection when the object is deleted."""
@@ -97,5 +97,6 @@ class BrokerConnection(object):
             self.disconnect()
             raise SocketDisconnectedError
         size = struct.unpack('!i', size)[0]
-        recvall_into(self._socket, self._buff, size)
-        return buffer(self._buff[4:4 + size])
+        output = bytearray(size)
+        recvall_into(self._socket, output, self._buffer_size)
+        return memoryview(output)[4:]  # skip past correlation-id


### PR DESCRIPTION
We ran into issues with `recvall_into` because it limited the size of
messages that could be received to `socket_receive_buffer_bytes`, and
some messages (such as MessageSets) could be considerably bigger.

This changes how `recvall_into` reads from the socket: while still
reading at most `socket_receive_buffer_bytes`-sized chunks at a time,
it should now be able to assemble messages of any size.

As a downside, that reverts `BrokerConnection.response` to allocating a
fresh bytearray on every call, but to make up for that, this commit now
avoids the slicing/copying that happened in its return statement, as
well as the copies of `chunk` that happened in `recvall_into`.

Signed-off-by: Yung-Chin Oei <yungchin@yungchin.nl>