### PR TITLE
Make sure retrying the rebalance also re-checks partition allocation.

### DIFF
--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -34,9 +34,18 @@ class ProduceFailureError(KafkaException):
     """Indicates a generic failure in the producer"""
     pass
 
+
 class NoMessagesConsumedError(KafkaException):
     """Indicates that no messages were returned from a MessageSet"""
     pass
+
+
+class PartitionOwnedError(KafkaException):
+    """Indicates a given partition is still owned in Zookeeper."""
+
+    def __init__(self, partition, *args, **kwargs):
+        super(PartitionOwnedError, self).__init__(*args, **kwargs)
+        self.partition = partition
 
 
 # Protocol Client Exceptions

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -71,6 +71,7 @@ class ThreadingHandler(Handler):
     QueueEmptyError = Queue.Empty
     Queue = Queue.Queue
     Event = threading.Event
+    Lock = threading.Lock
 
     def spawn(self, target, *args, **kwargs):
         t = threading.Thread(target=target, *args, **kwargs)


### PR DESCRIPTION
This fixes a case where a balanced consumer is trying to acquire partitions it should have because it's balancing information is out of date.  To fix, we ensure that every time we retry rebalancing that we re-check which partitions we should have.