### PR TITLE
Check held partitions

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -197,8 +197,7 @@ class BalancedConsumer():
                 if not self._running:
                     break
                 self._check_held_partitions()
-                # run every other autocommit cycle
-                time.sleep((self._auto_commit_interval_ms * 2) / 1000)
+                time.sleep(120)
             log.debug("Checker thread exiting")
         log.debug("Starting checker thread")
         return self._cluster.handler.spawn(checker)


### PR DESCRIPTION
This pull request adds a worker thread to `BalancedConsumer` that periodically compares ZooKeeper's list of held partitions with the consumer's internal list. If they're different, it rebalances.