### PR TITLE
Asynchronous Producer

### DIFF
--- a/pykafka/__init__.py
+++ b/pykafka/__init__.py
@@ -2,7 +2,7 @@ from broker import Broker
 from simpleconsumer import SimpleConsumer
 from cluster import Cluster
 from partition import Partition
-from producer import Producer
+from producer import Producer, SynchronousProducer
 from topic import Topic
 from client import KafkaClient
 from balancedconsumer import BalancedConsumer
@@ -11,4 +11,4 @@ __version__ = '1.1.1'
 
 
 __all__ = ["Broker", "SimpleConsumer", "Cluster", "Partition", "Producer",
-           "Topic", "KafkaClient", "BalancedConsumer"]
+           "Topic", "KafkaClient", "BalancedConsumer", "SynchronousProducer"]

--- a/pykafka/__init__.py
+++ b/pykafka/__init__.py
@@ -2,7 +2,7 @@ from broker import Broker
 from simpleconsumer import SimpleConsumer
 from cluster import Cluster
 from partition import Partition
-from producer import Producer, SynchronousProducer
+from producer import Producer
 from topic import Topic
 from client import KafkaClient
 from balancedconsumer import BalancedConsumer
@@ -11,4 +11,4 @@ __version__ = '1.1.1'
 
 
 __all__ = ["Broker", "SimpleConsumer", "Cluster", "Partition", "Producer",
-           "Topic", "KafkaClient", "BalancedConsumer", "SynchronousProducer"]
+           "Topic", "KafkaClient", "BalancedConsumer"]

--- a/pykafka/__init__.py
+++ b/pykafka/__init__.py
@@ -7,7 +7,7 @@ from topic import Topic
 from client import KafkaClient
 from balancedconsumer import BalancedConsumer
 
-__version__ = '1.1.1'
+__version__ = '2.0.0'
 
 
 __all__ = ["Broker", "SimpleConsumer", "Cluster", "Partition", "Producer",

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -45,6 +45,11 @@ class NoMessagesConsumedError(KafkaException):
     pass
 
 
+class ProducerQueueFullError(KafkaException):
+    """Indicates that one or more of the AsyncProducer's internal queues contain at least max_queued_messages messages"""
+    pass
+
+
 class ProducerStoppedException(KafkaException):
     """Raised when the Producer is used while not running"""
     pass

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -45,11 +45,6 @@ class NoMessagesConsumedError(KafkaException):
     pass
 
 
-class ProducerQueueFullError(KafkaException):
-    """Indicates that one or more of the AsyncProducer's internal queues contain at least max_queued_messages messages"""
-    pass
-
-
 class ProducerStoppedException(KafkaException):
     """Raised when the Producer is used while not running"""
     pass

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -50,6 +50,11 @@ class ProducerQueueFullError(KafkaException):
     pass
 
 
+class ProducerStoppedException(KafkaException):
+    """Raised when the Producer is used while not running"""
+    pass
+
+
 class OffsetRequestFailedError(KafkaException):
     """Indicates that OffsetRequests for offset resetting failed more times than the configured maximum"""
     pass

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -45,6 +45,11 @@ class NoMessagesConsumedError(KafkaException):
     pass
 
 
+class ProducerQueueFullError(KafkaException):
+    """Indicates that one or more of the AsyncProducer's internal queues contain at least max_queued_messages messages"""
+    pass
+
+
 class OffsetRequestFailedError(KafkaException):
     """Indicates that OffsetRequests for offset resetting failed more times than the configured maximum"""
     pass

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 __all__ = ["ResponseFuture", "Handler", "ThreadingHandler", "RequestHandler"]
 import atexit
+import functools
 import threading
 import Queue
 
@@ -72,6 +73,8 @@ class ThreadingHandler(Handler):
     Queue = Queue.Queue
     Event = threading.Event
     Lock = threading.Lock
+    # turn off RLock's super annoying default logging
+    RLock = functools.partial(threading.RLock, verbose=False)
 
     def spawn(self, target, *args, **kwargs):
         t = threading.Thread(target=target, *args, **kwargs)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -65,7 +65,7 @@ class Producer(object):
                  ack_timeout_ms=10 * 1000,
                  max_queued_messages=100000,
                  min_queued_messages=70000,
-                 linger_ms=0,
+                 linger_ms=5 * 1000,
                  block_on_queue_full=True,
                  sync=False):
         """Instantiate a new AsyncProducer

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -480,11 +480,11 @@ class OwnedBroker(object):
     def resolve_event_state(self):
         """Invariants for the Event variables used for thread synchronization
         """
-        if len(self.queue) >= self.producer._max_queued_messages:
-            self.slot_available.clear()
-            self.flush_ready.set()
-        elif len(self.queue) == 0:
+        if len(self.queue) < self.producer._max_queued_messages:
             self.slot_available.set()
-            self.flush_ready.clear()
         else:
-            self.slot_available.set()
+            self.slot_available.clear()
+        if len(self.queue) >= self.producer._min_queued_messages:
+            self.flush_ready.set()
+        else:
+            self.flush_ready.clear()

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -326,7 +326,11 @@ class AsyncProducer(Producer):
                     request, attempt = request_queue.get_nowait()
                 except Empty:
                     continue
-                self._send_request(broker, request, attempt)
+                try:
+                    self._send_request(broker, request, attempt)
+                except ProduceFailureError as e:
+                    log.error("Producer error: %s", e)
+
         request_queue = self._cluster.handler.Queue()
         log.info("Starting new produce worker thread for broker %s", broker.id)
         self._cluster.handler.spawn(worker)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -200,7 +200,7 @@ class Producer(object):
             raise ProducerStoppedException()
         partitions = self._topic.partitions.values()
         partition_id = self._partitioner(partitions, (message, partition_key)).id
-        message_partition_tup = (partition_key, message), partition_id
+        message_partition_tup = (partition_key, str(message)), partition_id
         self._produce(message_partition_tup)
         if self._synchronous:
             self._wait_all()

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -37,7 +37,7 @@ from .protocol import Message, ProduceRequest
 log = logging.getLogger(__name__)
 
 
-class Producer(object):
+class Producer():
     """
     This class implements the synchronous producer logic found in the
     JVM driver.

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -32,6 +32,7 @@ from .exceptions import (
     MessageSizeTooLarge,
     NotLeaderForPartition,
     ProduceFailureError,
+    ProducerQueueFullError,
     ProducerStoppedException,
     RequestTimedOut,
     SocketDisconnectedError,
@@ -111,9 +112,9 @@ class Producer(object):
         :type linger_ms: int
         :param block_on_queue_full: When the producer's message queue for a
             broker contains max_queued_messages, we must either stop accepting
-            new messages (block) or register an error. If True, this setting
+            new messages (block) or throw an error. If True, this setting
             indicates we should block until space is available in the queue.
-            If False, we should return immediately and indicate the error.
+            If False, we should throw an error immediately.
         :type block_on_queue_full: bool
         """
         self._cluster = cluster
@@ -215,9 +216,7 @@ class Producer(object):
                 yield (key, str(value)), self._partitioner(partitions, message).id
         if not self._running:
             raise ProducerStoppedException()
-        pairs = itertools.izip(self._produce(_partition_messages()), messages)
-        for message_enqueued in pairs:
-            yield message_enqueued
+        self._produce(_partition_messages())
 
     @raise_worker_exceptions
     def _produce(self, message_partition_tups):
@@ -228,7 +227,7 @@ class Producer(object):
         """
         for kv, partition_id in message_partition_tups:
             leader_id = self._topic.partitions[partition_id].leader.id
-            yield self._owned_brokers[leader_id].enqueue([(kv, partition_id)])
+            self._owned_brokers[leader_id].enqueue([(kv, partition_id)])
 
     @raise_worker_exceptions
     def _prepare_request(self, message_batch, owned_broker):
@@ -333,8 +332,7 @@ class Producer(object):
                 time.sleep(self._retry_backoff_ms / 1000)
                 # we have to call _produce here since the broker/partition
                 # target for each message may have changed
-                for _ in self._produce(to_retry, attempt):
-                    pass
+                self._produce(to_retry, attempt)
             else:
                 raise ProduceFailureError('Unable to produce messages. See log for details.')
 
@@ -435,9 +433,8 @@ class SynchronousProducer(Producer):
         :type linger_ms: int
         :param block_on_queue_full: When the producer's message queue for a
             broker contains max_queued_messages, we must either stop accepting
-            new messages (block) or register an error. If True, this setting
+            new messages (block) or throw an error. If True, this setting
             indicates we should block until space is available in the queue.
-            If False, we should return immediately and indicate the error.
         :type block_on_queue_full: bool
         """
         super(SynchronousProducer, self).__init__(
@@ -527,9 +524,7 @@ class OwnedBroker(object):
         :type acquire: bool
         """
         assert acquire or self.lock.locked()
-        available = self._wait_for_slot_available(acquire=acquire)
-        if not available:
-            return False
+        self._wait_for_slot_available(acquire=acquire)
         if acquire:
             self.lock.acquire()
         self.queue.extendleft(messages)
@@ -539,7 +534,6 @@ class OwnedBroker(object):
                 self.flush_ready.set()
         if acquire:
             self.lock.release()
-        return True
 
     def flush(self, linger_ms, acquire=True, release_inflight=False):
         """Pop messages from the end of the queue
@@ -613,8 +607,8 @@ class OwnedBroker(object):
             if self.producer._block_on_queue_full:
                 self.slot_available.wait()
             else:
-                return False
-        return True
+                raise ProducerQueueFullError("Queue full for broker %d",
+                                             self.broker.id)
 
     def resolve_event_state(self):
         """Invariants for the Event variables used for thread synchronization

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -169,7 +169,7 @@ class Producer(object):
         called because the with: block has ended, do wait for workers to finish.
         """
         # If the thread crashed, don't wait for it
-        self.stop(wait=self._worker_exception is None)
+        self.stop()
 
     def start(self):
         """Set up data structures and start worker threads"""
@@ -182,16 +182,10 @@ class Producer(object):
             self._running = True
         self.raise_worker_exceptions()
 
-    def stop(self, wait=True):
-        """Mark the producer as stopped
-
-        :param wait: Whether to wait for all pending messages to be sent
-            before returning
-        :type wait: bool
-        """
+    def stop(self):
+        """Mark the producer as stopped"""
         self._running = False
-        if wait:
-            self._wait_all()
+        self._wait_all()
 
     def produce(self, message, partition_key=None):
         """Produce a message.

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -360,6 +360,7 @@ class Producer(object):
         log.info("Blocking until all messages are sent")
         while any(q.message_is_pending() for q in self._owned_brokers.itervalues()):
             time.sleep(.3)
+            self.raise_worker_exceptions()
 
 
 class OwnedBroker(object):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -144,11 +144,9 @@ class AsyncProducer(object):
 
     def _wait_all(self):
         """Block until all messages in flight are sent"""
-        last_log = time.time()
+        log.info("Blocking until all messages are sent")
         while self.messages_inflight:
-            if time.time() - last_log >= .5:
-                log.debug("Blocking until all messages are sent")
-                last_log = time.time()
+            time.sleep(.3)
 
     def __enter__(self):
         """Context manager entry point - start the producer"""

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -193,21 +193,20 @@ class Producer(object):
         if wait:
             self._wait_all()
 
-    def produce(self, message):
+    def produce(self, message, partition_key=None):
         """Produce a message.
 
         :param message: The message to produce
-        :type message: str or (str, str) tuple
+        :type message: str
+        :param partition_key: The key to use when deciding which partition to send this
+            message to
+        :type partition_key: str
         """
         if not self._running:
             raise ProducerStoppedException()
         partitions = self._topic.partitions.values()
-        if isinstance(message, basestring):
-            key = None
-            value = message
-        else:
-            key, value = message
-        message_partition_tup = (key, str(value)), self._partitioner(partitions, message).id
+        partition_id = self._partitioner(partitions, (message, partition_key)).id
+        message_partition_tup = (partition_key, message), partition_id
         self._produce(message_partition_tup)
         if self._synchronous:
             self._wait_all()

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -63,8 +63,8 @@ class Producer(object):
                  retry_backoff_ms=100,
                  required_acks=1,
                  ack_timeout_ms=10 * 1000,
-                 max_queued_messages=10000,
-                 min_queued_messages=5000,
+                 max_queued_messages=100000,
+                 min_queued_messages=70000,
                  linger_ms=0,
                  block_on_queue_full=True,
                  sync=False):
@@ -102,7 +102,7 @@ class Producer(object):
             broker.
         :type min_queued_messages: int
         :param linger_ms: This setting gives the upper bound on the delay for
-            batching: once the producer gets max_queued_messages worth of
+            batching: once the producer gets min_queued_messages worth of
             messages for a broker, it will be sent immediately regardless of
             this setting.  However, if we have fewer than this many messages
             accumulated for this partition we will 'linger' for the specified

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -33,6 +33,7 @@ from .exceptions import (
     NotLeaderForPartition,
     ProduceFailureError,
     ProducerQueueFullError,
+    ProducerStoppedException,
     RequestTimedOut,
     SocketDisconnectedError,
     UnknownTopicOrPartition
@@ -207,6 +208,8 @@ class Producer(object):
                 else:
                     key, value = message
                 yield (key, str(value)), self._partitioner(partitions, message).id
+        if not self._running:
+            raise ProducerStoppedException()
         self._produce(_partition_messages())
 
     @raise_worker_exceptions

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -37,319 +37,7 @@ from .protocol import Message, ProduceRequest
 log = logging.getLogger(__name__)
 
 
-class Producer():
-    """
-    This class implements the synchronous producer logic found in the
-    JVM driver.
-    """
-    def __init__(self,
-                 cluster,
-                 topic,
-                 partitioner=random_partitioner,
-                 compression=CompressionType.NONE,
-                 max_retries=3,
-                 retry_backoff_ms=100,
-                 required_acks=1,
-                 ack_timeout_ms=10000,
-                 batch_size=200):
-        """Instantiate a new Producer.
-
-        :param cluster: The cluster to which to connect
-        :type cluster: :class:`pykafka.cluster.Cluster`
-        :param topic: The topic to which to produce messages
-        :type topic: :class:`pykafka.topic.Topic`
-        :param partitioner: The partitioner to use during message production
-        :type partitioner: :class:`pykafka.partitioners.BasePartitioner`
-        :param compression: The type of compression to use.
-        :type compression: :class:`pykafka.common.CompressionType`
-        :param max_retries: How many times to attempt to produce messages
-            before raising an error.
-        :type max_retries: int
-        :param retry_backoff_ms: The amount of time (in milliseconds) to
-            back off during produce request retries.
-        :type retry_backoff_ms: int
-        :param required_acks: How many other brokers must have committed the
-            data to their log and acknowledged this to the leader before a
-            request is considered complete?
-        :type required_acks: int
-        :param ack_timeout_ms: Amount of time (in milliseconds) to wait for
-            acknowledgment of a produce request.
-        :type ack_timeout_ms: int
-        :param batch_size: Size (in bytes) of batches to send to brokers.
-        :type batch_size: int
-        """
-        # See BaseProduce.__init__.__doc__ for docstring
-        self._cluster = cluster
-        self._topic = topic
-        self._partitioner = partitioner
-        self._compression = compression
-        self._max_retries = max_retries
-        self._retry_backoff_ms = retry_backoff_ms
-        self._required_acks = required_acks
-        self._ack_timeout_ms = ack_timeout_ms
-        self._batch_size = batch_size
-
-    def __repr__(self):
-        return "<{module}.{name} at {id_}>".format(
-            module=self.__class__.__module__,
-            name=self.__class__.__name__,
-            id_=hex(id(self))
-        )
-
-    def _send_request(self, broker, req, attempt, owned_broker=None):
-        """Send the produce request to the broker and handle the response.
-
-        :param broker: The broker to which to send the request
-        :type broker: :class:`pykafka.broker.Broker`
-        :param req: The produce request to send
-        :type req: :class:`pykafka.protocol.ProduceRequest`
-        :param attempt: The current attempt count. Used for retry logic
-        :type attempt: int
-        :param owned_broker: An OwnedBroker instance containing information
-            about the queue from which the messages in `req` were removed.
-            Only used when called from the
-            :class:`pykafka.producer.AsyncProducer`
-        :type owned_broker: :class:`pykafka.producer.OwnedBroker`
-        """
-
-        def _get_partition_msgs(partition_id, req):
-            """Get all the messages for the partitions from the request."""
-            messages = itertools.chain.from_iterable(
-                mset.messages
-                for topic, partitions in req.msets.iteritems()
-                for p_id, mset in partitions.iteritems()
-                if p_id == partition_id
-            )
-            for message in messages:
-                yield (message.partition_key, message.value), partition_id
-
-        # Do the request
-        to_retry = []
-        try:
-            response = broker.produce_messages(req)
-
-            # Figure out if we need to retry any messages
-            # TODO: Convert to using utils.handle_partition_responses
-            to_retry = []
-            for topic, partitions in response.topics.iteritems():
-                for partition, presponse in partitions.iteritems():
-                    if presponse.err == 0:
-                        if owned_broker is not None:
-                            msg_count = len(req.msets[topic][partition].messages)
-                            with owned_broker.lock:
-                                owned_broker.messages_inflight -= msg_count
-                        continue  # All's well
-                    if presponse.err == UnknownTopicOrPartition.ERROR_CODE:
-                        log.warning('Unknown topic: %s or partition: %s. '
-                                    'Retrying.', topic, partition)
-                    elif presponse.err == NotLeaderForPartition.ERROR_CODE:
-                        log.warning('Partition leader for %s/%s changed. '
-                                    'Retrying.', topic, partition)
-                        # Update cluster metadata to get new leader
-                        self._cluster.update()
-                        if owned_broker is not None:
-                            owned_broker.producer._update_leaders()
-                    elif presponse.err == RequestTimedOut.ERROR_CODE:
-                        log.warning('Produce request to %s:%s timed out. '
-                                    'Retrying.', broker.host, broker.port)
-                    elif presponse.err == InvalidMessageError.ERROR_CODE:
-                        log.warning('Encountered InvalidMessageError')
-                    elif presponse.err == InvalidMessageSize.ERROR_CODE:
-                        log.warning('Encountered InvalidMessageSize')
-                        continue
-                    elif presponse.err == MessageSizeTooLarge.ERROR_CODE:
-                        log.warning('Encountered MessageSizeTooLarge')
-                        continue
-                    to_retry.extend(_get_partition_msgs(partition, req))
-        except SocketDisconnectedError:
-            log.warning('Broker %s:%s disconnected. Retrying.',
-                        broker.host, broker.port)
-            self._cluster.update()
-            to_retry = [
-                ((message.partition_key, message.value), p_id)
-                for topic, partitions in req.msets.iteritems()
-                for p_id, mset in partitions.iteritems()
-                for message in mset.messages
-            ]
-
-        if to_retry:
-            attempt += 1
-            if attempt < self._max_retries:
-                time.sleep(self._retry_backoff_ms / 1000)
-                # we have to call _produce here since the broker/partition
-                # target for each message may have changed
-                self._produce(to_retry, attempt)
-            else:
-                raise ProduceFailureError('Unable to produce messages. See log for details.')
-
-    def _partition_messages(self, messages):
-        """Assign messages to partitions using the partitioner.
-
-        :param messages: Iterable of messages to publish.
-        :returns:        Generator of ((key, value), partition_id)
-        """
-        partitions = self._topic.partitions.values()
-        for message in messages:
-            if isinstance(message, basestring):
-                key = None
-                value = message
-            else:
-                key, value = message
-            value = str(value)
-            yield (key, value), self._partitioner(partitions, message).id
-
-    def _produce(self, message_partition_tups, attempt):
-        """Publish a set of messages to relevant brokers.
-
-        :param message_partition_tups: Messages with partitions assigned.
-        :type message_partition_tups:  tuples of ((key, value), partition_id)
-        """
-        # Requests grouped by broker
-        requests = defaultdict(lambda: ProduceRequest(
-            compression_type=self._compression,
-            required_acks=self._required_acks,
-            timeout=self._ack_timeout_ms,
-        ))
-
-        for ((key, value), partition_id) in message_partition_tups:
-            # N.B. This handles retries, so the leader lookup is needed
-            leader = self._topic.partitions[partition_id].leader
-            requests[leader].add_message(
-                Message(value, partition_key=key),
-                self._topic.name,
-                partition_id
-            )
-            # Send requests at the batch size
-            if requests[leader].message_count() >= self._batch_size:
-                self._send_request(leader, requests.pop(leader), attempt)
-
-        # Send any still not sent
-        for leader, req in requests.iteritems():
-            self._send_request(leader, req, attempt)
-
-    def produce(self, messages):
-        """Produce a set of messages.
-
-        :param messages: The messages to produce
-        :type messages: Iterable of str or (str, str) tuples
-        """
-        # Do partition distribution here. We need to be able to retry producing
-        # only *some* messages when a leader changes. Therefore, we don't want
-        # a random partition distribution changing that on the retry.
-        self._produce(self._partition_messages(messages), 0)
-
-
-class OwnedBroker():
-    """A packet of information for a producer queue
-
-    An OwnedBroker object contains thread-synchronization primitives corresponding
-    to a single broker for this producer.
-
-    :ivar lock: The lock used to control access to shared resources for this
-        queue
-    :type lock: threading.Lock
-    :ivar flush_ready: A condition variable that indicates that the queue is
-        ready to be flushed via requests to the broker
-    :type flush_ready: threading.Condition
-    :ivar slot_available: A condition variable that indicates that there is
-        at least one position free in the queue for a new message
-    :type slot_available: threading.Condition
-    :ivar queue: The message queue for this broker. Contains messages that have
-        been supplied as arguments to `produce()` waiting to be sent to the
-        broker.
-    :type queue: collections.deque
-    :ivar messages_inflight: A counter indicating how many messages have been
-        enqueued for this broker and not yet sent in a request.
-    :type messages_inflight: int
-    :ivar producer: The producer to which this OwnedBroker instance belongs
-    :type producer: :class:`pykafka.producer.AsyncProducer`
-    """
-    def __init__(self, producer, broker):
-        self.producer = producer
-        self.broker = broker
-        self.lock = threading.Lock()
-        self.flush_ready = threading.Event()
-        self.slot_available = threading.Event()
-        self.queue = deque()
-        self.messages_inflight = 0
-
-        def queue_reader():
-            while True:
-                batch = self.flush(self.producer._linger_ms)
-                if batch:
-                    self.producer._send_request(batch, self)
-        log.info("Starting new produce worker thread for broker %s", broker.id)
-        self.producer._cluster.handler.spawn(queue_reader)
-
-    @property
-    def message_inflight(self):
-        """
-        Indicates whether there are currently any messages that have been
-            `produce()`d and not yet sent to the broker
-        """
-        return self.messages_inflight > 0
-
-    def enqueue(self,
-                messages,
-                max_queued_messages,
-                block_on_queue_full,
-                acquire=True):
-        self._wait_for_available_slot(max_queued_messages, block_on_queue_full)
-        if acquire:
-            self.lock.acquire()
-        self.queue.extendleft(messages)
-        self.messages_inflight += len(messages)
-        if len(self.queue) >= max_queued_messages:
-            if not self.flush_ready.is_set():
-                self.flush_ready.set()
-        if acquire:
-            self.lock.release()
-
-    def flush(self, linger_ms, acquire=True, release_inflight=False):
-        self._wait_for_used_slot(linger_ms)
-        if acquire:
-            self.lock.acquire()
-        batch = [self.queue.pop() for _ in xrange(len(self.queue))]
-        if release_inflight:
-            self.messages_inflight -= len(batch)
-        if not self.slot_available.is_set():
-            self.slot_available.set()
-        if acquire:
-            self.lock.release()
-        return batch
-
-    def resolve_event_state(self, max_queued_messages):
-        if len(self.queue) >= max_queued_messages:
-            self.slot_available.clear()
-            self.flush_ready.set()
-        elif len(self.queue) == 0:
-            self.slot_available.set()
-            self.flush_ready.clear()
-        else:
-            self.slot_available.set()
-
-    def _wait_for_used_slot(self, linger_ms):
-        if len(self.queue) == 0:
-            with self.lock:
-                if len(self.queue) == 0:
-                    self.flush_ready.clear()
-            self.flush_ready.wait(linger_ms / 1000)
-
-    def _wait_for_available_slot(self,
-                                 max_queued_messages,
-                                 block_on_queue_full):
-        if len(self.queue) >= max_queued_messages:
-            with self.lock:
-                if len(self.queue) >= max_queued_messages:
-                    self.slot_available.clear()
-            if block_on_queue_full:
-                self.slot_available.wait()
-            else:
-                raise ProducerQueueFullError("Queue full for broker %d",
-                                             self.broker.id)
-
-
-class AsyncProducer():
+class AsyncProducer(object):
     """
     This class implements asynchronous producer logic similar to that found in
     the JVM driver. In inherits from the synchronous implementation.
@@ -424,10 +112,20 @@ class AsyncProducer():
         self._running = False
         self.start()
 
+    def __repr__(self):
+        return "<{module}.{name} at {id_}>".format(
+            module=self.__class__.__module__,
+            name=self.__class__.__name__,
+            id_=hex(id(self))
+        )
+
+    @property
+    def messages_inflight(self):
+        return any(q.message_inflight for q in self._owned_brokers.itervalues())
+
     def start(self):
         """Connect to brokers and start worker threads"""
         if not self._running:
-            self._setup_internal_producer()
             self._owned_brokers = {}
             for partition in self._topic.partitions.values():
                 if partition.leader.id not in self._owned_brokers:
@@ -439,7 +137,7 @@ class AsyncProducer():
         """Mark as stopped and wait for all inflight messages to send"""
         self._running = False
         last_log = time.time()
-        while any(q.message_inflight for q in self._owned_brokers.itervalues()):
+        while self.messages_inflight:
             if time.time() - last_log >= .5:
                 log.info("Waiting for all worker threads to exit")
                 last_log = time.time()
@@ -452,19 +150,6 @@ class AsyncProducer():
     def __exit__(self, exc_type, exc_value, traceback):
         """Context manager exit point - stop the producer"""
         self.stop()
-
-    def _setup_internal_producer(self):
-        """Instantiate the internal producer"""
-        self._producer = Producer(
-            self._cluster,
-            self._topic,
-            self._partitioner,
-            compression=self._compression,
-            max_retries=self._max_retries,
-            retry_backoff_ms=self._retry_backoff_ms,
-            required_acks=self._required_acks,
-            ack_timeout_ms=self._ack_timeout_ms,
-        )
 
     def _produce(self, message_partition_tups):
         """Enqueue a set of messages for the relevant brokers
@@ -479,7 +164,7 @@ class AsyncProducer():
                 self._max_queued_messages,
                 self._block_on_queue_full)
 
-    def _send_request(self, message_batch, owned_broker):
+    def _prepare_request(self, message_batch, owned_broker):
         """Prepare a request and send it to the broker
 
         :param message_batch: An iterable of messages to send
@@ -501,8 +186,7 @@ class AsyncProducer():
                 partition_id
             )
         try:
-            self._producer._send_request(owned_broker.broker, request, 0,
-                                         owned_broker)
+            self._send_request(request, 0, owned_broker)
         except ProduceFailureError as e:
             log.error("Producer error: %s", e)
 
@@ -532,10 +216,312 @@ class AsyncProducer():
             owned_broker.resolve_event_state(self._max_queued_messages)
             owned_broker.lock.release()
 
+    def _partition_messages(self, messages):
+        """Assign messages to partitions using the partitioner.
+
+        :param messages: Iterable of messages to publish.
+        :returns:        Generator of ((key, value), partition_id)
+        """
+        partitions = self._topic.partitions.values()
+        for message in messages:
+            if isinstance(message, basestring):
+                key = None
+                value = message
+            else:
+                key, value = message
+            value = str(value)
+            yield (key, value), self._partitioner(partitions, message).id
+
+    def _send_request(self, req, attempt, owned_broker):
+        """Send the produce request to the broker and handle the response.
+
+        :param broker: The broker to which to send the request
+        :type broker: :class:`pykafka.broker.Broker`
+        :param req: The produce request to send
+        :type req: :class:`pykafka.protocol.ProduceRequest`
+        :param attempt: The current attempt count. Used for retry logic
+        :type attempt: int
+        :param owned_broker: An OwnedBroker instance containing information
+            about the queue from which the messages in `req` were removed.
+            Only used when called from the
+            :class:`pykafka.producer.AsyncProducer`
+        :type owned_broker: :class:`pykafka.producer.OwnedBroker`
+        """
+
+        def _get_partition_msgs(partition_id, req):
+            """Get all the messages for the partitions from the request."""
+            messages = itertools.chain.from_iterable(
+                mset.messages
+                for topic, partitions in req.msets.iteritems()
+                for p_id, mset in partitions.iteritems()
+                if p_id == partition_id
+            )
+            for message in messages:
+                yield (message.partition_key, message.value), partition_id
+
+        # Do the request
+        to_retry = []
+        try:
+            response = owned_broker.broker.produce_messages(req)
+
+            # Figure out if we need to retry any messages
+            # TODO: Convert to using utils.handle_partition_responses
+            to_retry = []
+            for topic, partitions in response.topics.iteritems():
+                for partition, presponse in partitions.iteritems():
+                    if presponse.err == 0:
+                        if owned_broker is not None:
+                            msg_count = len(req.msets[topic][partition].messages)
+                            with owned_broker.lock:
+                                owned_broker.messages_inflight -= msg_count
+                        continue  # All's well
+                    if presponse.err == UnknownTopicOrPartition.ERROR_CODE:
+                        log.warning('Unknown topic: %s or partition: %s. '
+                                    'Retrying.', topic, partition)
+                    elif presponse.err == NotLeaderForPartition.ERROR_CODE:
+                        log.warning('Partition leader for %s/%s changed. '
+                                    'Retrying.', topic, partition)
+                        # Update cluster metadata to get new leader
+                        self._cluster.update()
+                        if owned_broker is not None:
+                            owned_broker.producer._update_leaders()
+                    elif presponse.err == RequestTimedOut.ERROR_CODE:
+                        log.warning('Produce request to %s:%s timed out. '
+                                    'Retrying.', owned_broker.broker.host,
+                                    owned_broker.broker.port)
+                    elif presponse.err == InvalidMessageError.ERROR_CODE:
+                        log.warning('Encountered InvalidMessageError')
+                    elif presponse.err == InvalidMessageSize.ERROR_CODE:
+                        log.warning('Encountered InvalidMessageSize')
+                        continue
+                    elif presponse.err == MessageSizeTooLarge.ERROR_CODE:
+                        log.warning('Encountered MessageSizeTooLarge')
+                        continue
+                    to_retry.extend(_get_partition_msgs(partition, req))
+        except SocketDisconnectedError:
+            log.warning('Broker %s:%s disconnected. Retrying.',
+                        owned_broker.broker.host,
+                        owned_broker.broker.port)
+            self._cluster.update()
+            to_retry = [
+                ((message.partition_key, message.value), p_id)
+                for topic, partitions in req.msets.iteritems()
+                for p_id, mset in partitions.iteritems()
+                for message in mset.messages
+            ]
+
+        if to_retry:
+            attempt += 1
+            if attempt < self._max_retries:
+                time.sleep(self._retry_backoff_ms / 1000)
+                # we have to call _produce here since the broker/partition
+                # target for each message may have changed
+                self._produce(to_retry, attempt)
+            else:
+                raise ProduceFailureError('Unable to produce messages. See log for details.')
+
     def produce(self, messages):
         """Produce a set of messages.
 
         :param messages: The messages to produce
         :type messages: Iterable of str or (str, str) tuples
         """
-        self._produce(self._producer._partition_messages(messages))
+        self._produce(self._partition_messages(messages))
+
+
+class Producer(AsyncProducer):
+    """
+    This class implements the synchronous producer logic found in the
+    JVM driver.
+    """
+    def __init__(self,
+                 cluster,
+                 topic,
+                 partitioner=random_partitioner,
+                 compression=CompressionType.NONE,
+                 max_retries=3,
+                 retry_backoff_ms=100,
+                 required_acks=1,
+                 ack_timeout_ms=10000,
+                 max_queued_messages=10000,
+                 linger_ms=0,
+                 block_on_queue_full=True):
+        """Instantiate a new Producer.
+
+        :param cluster: The cluster to which to connect
+        :type cluster: :class:`pykafka.cluster.Cluster`
+        :param topic: The topic to which to produce messages
+        :type topic: :class:`pykafka.topic.Topic`
+        :param partitioner: The partitioner to use during message production
+        :type partitioner: :class:`pykafka.partitioners.BasePartitioner`
+        :param compression: The type of compression to use.
+        :type compression: :class:`pykafka.common.CompressionType`
+        :param max_retries: How many times to attempt to produce messages
+            before raising an error.
+        :type max_retries: int
+        :param retry_backoff_ms: The amount of time (in milliseconds) to
+            back off during produce request retries.
+        :type retry_backoff_ms: int
+        :param required_acks: How many other brokers must have committed the
+            data to their log and acknowledged this to the leader before a
+            request is considered complete?
+        :type required_acks: int
+        :param ack_timeout_ms: Amount of time (in milliseconds) to wait for
+            acknowledgment of a produce request.
+        :type ack_timeout_ms: int
+        :param max_queued_messages: The maximum number of messages the producer
+            can have waiting to be sent to the broker. If messages are sent
+            faster than they can be delivered to the broker, the producer will
+            either block or throw an exception based on the preference specified
+            by block_on_queue_full.
+        :type max_queued_messages: int
+        :param linger_ms: This setting gives the upper bound on the delay for
+            batching: once the producer gets max_queued_messages worth of
+            messages for a broker, it will be sent immediately regardless of
+            this setting.  However, if we have fewer than this many messages
+            accumulated for this partition we will 'linger' for the specified
+            time waiting for more records to show up. linger_ms=0 indicates no
+            lingering.
+        :type linger_ms: int
+        :param block_on_queue_full: When the producer's message queue for a
+            broker contains max_queued_messages, we must either stop accepting
+            new messages (block) or throw an error. If True, this setting
+            indicates we should block until space is available in the queue.
+        :type block_on_queue_full: bool
+        """
+        super(Producer, self).__init__(
+            cluster,
+            topic,
+            partitioner=partitioner,
+            compression=compression,
+            max_retries=max_retries,
+            retry_backoff_ms=retry_backoff_ms,
+            required_acks=required_acks,
+            ack_timeout_ms=ack_timeout_ms,
+            max_queued_messages=max_queued_messages,
+            linger_ms=linger_ms,
+            block_on_queue_full=block_on_queue_full
+        )
+
+    def produce(self, messages):
+        """Produce a set of messages.
+
+        :param messages: The messages to produce
+        :type messages: Iterable of str or (str, str) tuples
+        """
+        super(Producer, self).produce(messages)
+        last_log = time.time()
+        while self.messages_inflight:
+            if time.time() - last_log >= .5:
+                log.debug("Blocking until all messages are sent")
+                last_log = time.time()
+
+
+class OwnedBroker(object):
+    """An abstraction over a broker connected to by the producer
+
+    An OwnedBroker object contains thread-synchronization primitives corresponding
+    to a single broker for this producer.
+
+    :ivar lock: The lock used to control access to shared resources for this
+        queue
+    :type lock: threading.Lock
+    :ivar flush_ready: A condition variable that indicates that the queue is
+        ready to be flushed via requests to the broker
+    :type flush_ready: threading.Condition
+    :ivar slot_available: A condition variable that indicates that there is
+        at least one position free in the queue for a new message
+    :type slot_available: threading.Condition
+    :ivar queue: The message queue for this broker. Contains messages that have
+        been supplied as arguments to `produce()` waiting to be sent to the
+        broker.
+    :type queue: collections.deque
+    :ivar messages_inflight: A counter indicating how many messages have been
+        enqueued for this broker and not yet sent in a request.
+    :type messages_inflight: int
+    :ivar producer: The producer to which this OwnedBroker instance belongs
+    :type producer: :class:`pykafka.producer.AsyncProducer`
+    """
+    def __init__(self, producer, broker):
+        self.producer = producer
+        self.broker = broker
+        self.lock = threading.Lock()
+        self.flush_ready = threading.Event()
+        self.slot_available = threading.Event()
+        self.queue = deque()
+        self.messages_inflight = 0
+
+        def queue_reader():
+            while True:
+                batch = self.flush(self.producer._linger_ms)
+                if batch:
+                    self.producer._prepare_request(batch, self)
+        log.info("Starting new produce worker thread for broker %s", broker.id)
+        self.producer._cluster.handler.spawn(queue_reader)
+
+    @property
+    def message_inflight(self):
+        """
+        Indicates whether there are currently any messages that have been
+            `produce()`d and not yet sent to the broker
+        """
+        return self.messages_inflight > 0
+
+    def enqueue(self,
+                messages,
+                max_queued_messages,
+                block_on_queue_full,
+                acquire=True):
+        self._wait_for_available_slot(max_queued_messages, block_on_queue_full)
+        if acquire:
+            self.lock.acquire()
+        self.queue.extendleft(messages)
+        self.messages_inflight += len(messages)
+        if len(self.queue) >= max_queued_messages:
+            if not self.flush_ready.is_set():
+                self.flush_ready.set()
+        if acquire:
+            self.lock.release()
+
+    def flush(self, linger_ms, acquire=True, release_inflight=False):
+        self._wait_for_used_slot(linger_ms)
+        if acquire:
+            self.lock.acquire()
+        batch = [self.queue.pop() for _ in xrange(len(self.queue))]
+        if release_inflight:
+            self.messages_inflight -= len(batch)
+        if not self.slot_available.is_set():
+            self.slot_available.set()
+        if acquire:
+            self.lock.release()
+        return batch
+
+    def resolve_event_state(self, max_queued_messages):
+        if len(self.queue) >= max_queued_messages:
+            self.slot_available.clear()
+            self.flush_ready.set()
+        elif len(self.queue) == 0:
+            self.slot_available.set()
+            self.flush_ready.clear()
+        else:
+            self.slot_available.set()
+
+    def _wait_for_used_slot(self, linger_ms):
+        if len(self.queue) == 0:
+            with self.lock:
+                if len(self.queue) == 0:
+                    self.flush_ready.clear()
+            self.flush_ready.wait(linger_ms / 1000)
+
+    def _wait_for_available_slot(self,
+                                 max_queued_messages,
+                                 block_on_queue_full):
+        if len(self.queue) >= max_queued_messages:
+            with self.lock:
+                if len(self.queue) >= max_queued_messages:
+                    self.slot_available.clear()
+            if block_on_queue_full:
+                self.slot_available.wait()
+            else:
+                raise ProducerQueueFullError("Queue full for broker %d",
+                                             self.broker.id)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -453,9 +453,9 @@ class OwnedBroker(object):
             to contain messages before returning
         :type linger_ms: int
         """
-        if len(self.queue) == 0:
+        if len(self.queue) < self.producer._min_queued_messages:
             with self.lock:
-                if len(self.queue) == 0:
+                if len(self.queue) < self.producer._min_queued_messages:
                     self.flush_ready.clear()
             self.flush_ready.wait(linger_ms / 1000)
 

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -46,9 +46,7 @@ log = logging.getLogger(__name__)
 
 
 class Producer(object):
-    """
-    This class implements asynchronous producer logic similar to that found in
-    the JVM driver.
+    """Implements asynchronous producer logic similar to the JVM driver.
 
     It creates a thread of execution for each broker that is the leader of
     one or more of its topic's partitions. Each of these threads (which may
@@ -140,8 +138,7 @@ class Producer(object):
         self.start()
 
     def raise_worker_exceptions(fn):
-        """Decorator that raises exceptions encountered on worker threads
-        """
+        """Decorator that raises exceptions encountered on worker threads"""
         def wrapped(self, *args, **kwargs):
             retval = fn(self, *args, **kwargs)
             if self._worker_exception is not None:
@@ -166,7 +163,6 @@ class Producer(object):
 
     def __enter__(self):
         """Context manager entry point - start the producer"""
-        self.start()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -162,13 +162,7 @@ class Producer(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """Context manager exit point - stop the producer
-
-        If __exit__ is being called as a result of self._worker_exception
-        being raised, don't wait on the workers to finish. If __exit__ is being
-        called because the with: block has ended, do wait for workers to finish.
-        """
-        # If the thread crashed, don't wait for it
+        """Context manager exit point - stop the producer"""
         self.stop()
 
     def start(self):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -336,9 +336,7 @@ class AsyncProducer(object):
 
 
 class Producer(AsyncProducer):
-    """
-    This class implements the synchronous producer logic found in the
-    JVM driver.
+    """ This class implements the synchronous producer logic found in the JVM driver.
     """
     def __init__(self,
                  cluster,

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -140,17 +140,11 @@ class Producer(object):
         """Context manager exit point - stop the producer
 
         If __exit__ is being called as a result of self._worker_exception
-        being raised, don't wait on the workers to finish - just re-raise
-        the exception. If __exit__ is being called because the with: block
-        has ended, do wait for workers to finish.
+        being raised, don't wait on the workers to finish. If __exit__ is being
+        called because the with: block has ended, do wait for workers to finish.
         """
         # If the thread crashed, don't wait for it
-        if self._worker_exception is not None:
-            log.exception(traceback)
-            self.stop(wait=False)
-            raise self._worker_exception
-        else:
-            self.stop()
+        self.stop(wait=self._worker_exception is None)
 
     def start(self):
         """Set up data structures and start worker threads"""
@@ -175,6 +169,8 @@ class Producer(object):
         self._running = False
         if wait:
             self._wait_all()
+        if self._worker_exception is not None:
+            raise self._worker_exception
 
     def produce(self, messages):
         """Produce a set of messages.

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -193,7 +193,7 @@ class Producer(object):
         if not self._running:
             raise ProducerStoppedException()
         partitions = self._topic.partitions.values()
-        partition_id = self._partitioner(partitions, (message, partition_key)).id
+        partition_id = self._partitioner(partitions, partition_key).id
         message_partition_tup = (partition_key, str(message)), partition_id
         self._produce(message_partition_tup)
         if self._synchronous:

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -211,7 +211,7 @@ class Producer():
             # Send requests at the batch size
             if requests[leader].message_count() >= self._batch_size:
                 self._prepare_request(leader,
-                                      requests.pop(leader.id),
+                                      requests.pop(leader),
                                       attempt)
 
         # Send any still not sent

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -46,6 +46,12 @@ class Producer(object):
     """
     This class implements asynchronous producer logic similar to that found in
     the JVM driver.
+
+    It creates a thread of execution for each broker that is the leader of
+    one or more of its topic's partitions. Each of these threads (which may
+    use `threading` or some other parallelism implementation like `gevent`)
+    is associated with a queue that holds the messages that are waiting to be
+    sent to that queue's broker.
     """
     def __init__(self,
                  cluster,
@@ -75,9 +81,9 @@ class Producer(object):
         :param retry_backoff_ms: The amount of time (in milliseconds) to
             back off during produce request retries.
         :type retry_backoff_ms: int
-        :param required_acks: The number of other brokers must have committed
-            the data to their log and acknowledged this to the leader before a
-            request is considered complete
+        :param required_acks: The number of other brokers that must have
+            committed the data to their log and acknowledged this to the leader
+            before a request is considered complete
         :type required_acks: int
         :param ack_timeout_ms: The amount of time (in milliseconds) to wait for
             acknowledgment of a produce request.

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -462,12 +462,6 @@ class AsyncProducer():
         :param message_partition_tups: Messages with partitions assigned.
         :type message_partition_tups: tuples of ((key, value), partition_id)
         """
-        # group messages by destination broker
-        messages_by_leader = defaultdict(list)
-        for ((key, value), partition_id) in message_partition_tups:
-            leader = self._topic.partitions[partition_id].leader
-            messages_by_leader[leader.id].append(((key, value), partition_id))
-
         # enqueue messages in the appropriate queue
         for ((key, value), partition_id) in message_partition_tups:
             leader = self._topic.partitions[partition_id].leader
@@ -483,7 +477,7 @@ class AsyncProducer():
                     raise ProducerQueueFullError("Queue full for broker %d",
                                                  leader.id)
             with q_info.lock:
-                q_info.queue.extendleft(((key, value), partition_id))
+                q_info.queue.extendleft([((key, value), partition_id)])
                 q_info.messages_inflight += 1
                 # should only set this if queue is full or timeout
                 if len(q_info.queue) >= self._max_queued_messages:

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -329,10 +329,9 @@ class AsyncProducer(Producer):
                 time.sleep(.0001)
                 try:
                     request, attempt = request_queue.get_nowait()
+                    self._send_request(broker, request, attempt)
                 except Empty:
                     continue
-                try:
-                    self._send_request(broker, request, attempt)
                 except ProduceFailureError as e:
                     log.error("Producer error: %s", e)
 

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -135,7 +135,8 @@ class Producer():
                 for partition, presponse in partitions.iteritems():
                     if presponse.err == 0:
                         if q_info is not None:
-                            q_info.messages_inflight -= 1
+                            msg_count = len(req.msets[topic][partition].messages)
+                            q_info.messages_inflight -= msg_count
                         continue  # All's well
                     if presponse.err == UnknownTopicOrPartition.ERROR_CODE:
                         log.warning('Unknown topic: %s or partition: %s. '

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -17,7 +17,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-__all__ = ["Producer", "AsyncProducer"]
+__all__ = ["Producer", "SynchronousProducer"]
 from collections import defaultdict, deque
 import itertools
 import logging
@@ -36,7 +36,7 @@ from .protocol import Message, ProduceRequest
 log = logging.getLogger(__name__)
 
 
-class AsyncProducer(object):
+class Producer(object):
     """
     This class implements asynchronous producer logic similar to that found in
     the JVM driver. In inherits from the synchronous implementation.
@@ -332,7 +332,7 @@ class AsyncProducer(object):
         self._produce(self._partition_messages(messages))
 
 
-class Producer(AsyncProducer):
+class SynchronousProducer(Producer):
     """ This class implements the synchronous producer logic found in the JVM driver.
     """
     def __init__(self,
@@ -390,7 +390,7 @@ class Producer(AsyncProducer):
             indicates we should block until space is available in the queue.
         :type block_on_queue_full: bool
         """
-        super(Producer, self).__init__(
+        super(SynchronousProducer, self).__init__(
             cluster,
             topic,
             partitioner=partitioner,
@@ -410,7 +410,7 @@ class Producer(AsyncProducer):
         :param messages: The messages to produce
         :type messages: Iterable of str or (str, str) tuples
         """
-        super(Producer, self).produce(messages)
+        super(SynchronousProducer, self).produce(messages)
         self._wait_all()
 
 

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -457,7 +457,7 @@ class OwnedBroker(object):
             with self.lock:
                 if len(self.queue) < self.producer._min_queued_messages:
                     self.flush_ready.clear()
-            self.flush_ready.wait(linger_ms / 1000)
+            self.flush_ready.wait((linger_ms / 1000) if linger_ms > 0 else None)
 
     def _wait_for_slot_available(self):
         """Block until the queue has at least one slot not containing a message"""

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -275,7 +275,6 @@ class SimpleConsumer():
             while True:
                 if not self._running:
                     break
-                log.debug("fetch loop %s", self._consumer_group)
                 self.fetch()
                 time.sleep(.0001)
             log.debug("Fetcher thread exiting")

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -275,6 +275,7 @@ class SimpleConsumer():
             while True:
                 if not self._running:
                     break
+                log.debug("fetch loop %s", self._consumer_group)
                 self.fetch()
                 time.sleep(.0001)
             log.debug("Fetcher thread exiting")

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 from .balancedconsumer import BalancedConsumer
 from .common import OffsetType
 from .partition import Partition
-from .producer import Producer, AsyncProducer
+from .producer import Producer, SynchronousProducer
 from .protocol import PartitionOffsetRequest
 from .simpleconsumer import SimpleConsumer
 
@@ -74,12 +74,12 @@ class Topic():
         """
         return Producer(self._cluster, self, **kwargs)
 
-    def get_async_producer(self, **kwargs):
+    def get_sync_producer(self, **kwargs):
         """Create a :class:`pykafka.producer.AsyncProducer` for this topic.
 
         For a description of all available `kwargs`, see the Producer docstring.
         """
-        return AsyncProducer(self._cluster, self, **kwargs)
+        return SynchronousProducer(self._cluster, self, **kwargs)
 
     def fetch_offset_limits(self, offsets_before, max_offsets=1):
         """Get earliest or latest offset.

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -75,7 +75,7 @@ class Topic():
         return Producer(self._cluster, self, **kwargs)
 
     def get_sync_producer(self, **kwargs):
-        """Create a :class:`pykafka.producer.AsyncProducer` for this topic.
+        """Create a :class:`pykafka.producer.SynchronousProducer` for this topic.
 
         For a description of all available `kwargs`, see the Producer docstring.
         """

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 from .balancedconsumer import BalancedConsumer
 from .common import OffsetType
 from .partition import Partition
-from .producer import Producer, SynchronousProducer
+from .producer import Producer
 from .protocol import PartitionOffsetRequest
 from .simpleconsumer import SimpleConsumer
 
@@ -75,11 +75,11 @@ class Topic():
         return Producer(self._cluster, self, **kwargs)
 
     def get_sync_producer(self, **kwargs):
-        """Create a :class:`pykafka.producer.SynchronousProducer` for this topic.
+        """Create a :class:`pykafka.producer.Producer` for this topic.
 
         For a description of all available `kwargs`, see the Producer docstring.
         """
-        return SynchronousProducer(self._cluster, self, **kwargs)
+        return Producer(self._cluster, self, sync=True, **kwargs)
 
     def fetch_offset_limits(self, offsets_before, max_offsets=1):
         """Get earliest or latest offset.

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -98,7 +98,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         cls.topic_name = 'test-data'
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.client = KafkaClient(cls.kafka.brokers)
-        prod = cls.client.topics[cls.topic_name].get_producer()
+        prod = cls.client.topics[cls.topic_name].get_producer(min_queued_messages=1)
         for i in xrange(1000):
             prod.produce('msg {num}'.format(num=i))
 

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -98,7 +98,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         cls.topic_name = 'test-data'
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.client = KafkaClient(cls.kafka.brokers)
-        prod = cls.client.topics[cls.topic_name].get_producer(batch_size=5)
+        prod = cls.client.topics[cls.topic_name].get_producer()
         prod.produce('msg {num}'.format(num=i) for i in xrange(1000))
 
     @classmethod

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -99,7 +99,8 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.client = KafkaClient(cls.kafka.brokers)
         prod = cls.client.topics[cls.topic_name].get_producer()
-        prod.produce('msg {num}'.format(num=i) for i in xrange(1000))
+        for i in xrange(1000):
+            prod.produce('msg {num}'.format(num=i))
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/pykafka/test_partition.py
+++ b/tests/pykafka/test_partition.py
@@ -14,7 +14,7 @@ class TestPartitionInfo(unittest2.TestCase):
         cls.producer = cls.client.topics[cls.topic_name].get_producer()
         cls.total_messages = 99
         for i in range(cls.total_messages):
-            cls.producer.produce(["message %s" % i])
+            cls.producer.produce("message %s" % i)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/pykafka/test_partition.py
+++ b/tests/pykafka/test_partition.py
@@ -11,7 +11,8 @@ class TestPartitionInfo(unittest2.TestCase):
         cls.topic_name = 'test-data'
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.client = KafkaClient(cls.kafka.brokers)
-        cls.producer = cls.client.topics[cls.topic_name].get_producer()
+        topic = cls.client.topics[cls.topic_name]
+        cls.producer = topic.get_producer(min_queued_messages=1)
         cls.total_messages = 99
         for i in range(cls.total_messages):
             cls.producer.produce("message %s" % i)

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -31,7 +31,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         # produced in a previous test
         payload = uuid4().bytes
 
-        prod = self.client.topics[self.topic_name].get_sync_producer()
+        prod = self.client.topics[self.topic_name].get_sync_producer(min_queued_messages=1)
         prod.produce(payload)
 
         # set a timeout so we don't wait forever if we break producer code
@@ -41,7 +41,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
     def test_async_produce(self):
         payload = uuid4().bytes
 
-        prod = self.client.topics[self.topic_name].get_producer()
+        prod = self.client.topics[self.topic_name].get_producer(min_queued_messages=1)
         prod.produce(payload)
 
         message = self.consumer.consume()
@@ -51,7 +51,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         """Ensure that the producer works as a context manager"""
         payload = uuid4().bytes
 
-        with self.client.topics[self.topic_name].get_producer() as producer:
+        with self.client.topics[self.topic_name].get_producer(min_queued_messages=1) as producer:
             producer.produce(payload)
 
         message = self.consumer.consume()
@@ -85,7 +85,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         """Ensure that an exception on a worker thread is raised to the main thread"""
         topic = self.client.topics[self.topic_name]
         with self.assertRaises(ValueError):
-            with topic.get_producer() as producer:
+            with topic.get_producer(min_queued_messages=1) as producer:
                 # get some dummy data into the queue that will cause a crash when flushed
                 # specifically, this tuple causes a crash since its first element is
                 # not a two-tuple
@@ -97,7 +97,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         """Ensure that the producer can handle unicode strings"""
         topic = self.client.topics[self.topic_name]
         payload = u"tester"
-        with topic.get_producer() as producer:
+        with topic.get_producer(min_queued_messages=1) as producer:
             producer.produce(payload)
         message = self.consumer.consume()
         self.assertTrue(message.value == payload)

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -32,7 +32,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         payload = uuid4().bytes
 
         prod = self.client.topics[self.topic_name].get_sync_producer()
-        prod.produce([payload])
+        prod.produce(payload)
 
         # set a timeout so we don't wait forever if we break producer code
         message = self.consumer.consume()
@@ -42,7 +42,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         payload = uuid4().bytes
 
         prod = self.client.topics[self.topic_name].get_producer()
-        prod.produce([payload])
+        prod.produce(payload)
 
         message = self.consumer.consume()
         self.assertTrue(message.value == payload)
@@ -52,7 +52,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         payload = uuid4().bytes
 
         with self.client.topics[self.topic_name].get_producer() as producer:
-            producer.produce([payload])
+            producer.produce(payload)
 
         message = self.consumer.consume()
         self.assertTrue(message.value == payload)
@@ -65,7 +65,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
                                 linger_ms=1000) as producer:
             with self.assertRaises(ProducerQueueFullError):
                 while True:
-                    producer.produce([uuid4().bytes])
+                    producer.produce(uuid4().bytes)
         while self.consumer.consume() is not None:
             time.sleep(.05)
 
@@ -75,8 +75,8 @@ class ProducerIntegrationTests(unittest2.TestCase):
         topic = self.client.topics[self.topic_name]
         with topic.get_producer(linger_ms=linger * 1000) as producer:
             start = time.time()
-            producer.produce([uuid4().bytes])
-            producer.produce([uuid4().bytes])
+            producer.produce(uuid4().bytes)
+            producer.produce(uuid4().bytes)
         self.assertEqual(int(time.time() - start), int(linger))
         self.consumer.consume()
         self.consumer.consume()

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -73,9 +73,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         """Ensure that the context manager waits for linger_ms milliseconds"""
         linger = 3
         topic = self.client.topics[self.topic_name]
-        with topic.get_producer(block_on_queue_full=False,
-                                max_queued_messages=10,
-                                linger_ms=linger * 1000) as producer:
+        with topic.get_producer(linger_ms=linger * 1000) as producer:
             start = time.time()
             producer.produce([uuid4().bytes])
             producer.produce([uuid4().bytes])

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -93,6 +93,14 @@ class ProducerIntegrationTests(unittest2.TestCase):
         while self.consumer.consume() is not None:
             time.sleep(.05)
 
+    def test_async_produce_unicode(self):
+        """Ensure that the producer can handle unicode strings"""
+        topic = self.client.topics[self.topic_name]
+        payload = u"tester"
+        with topic.get_producer() as producer:
+            producer.produce(payload)
+        message = self.consumer.consume()
+        self.assertTrue(message.value == payload)
 
 if __name__ == "__main__":
     unittest2.main()

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -81,6 +81,18 @@ class ProducerIntegrationTests(unittest2.TestCase):
         self.consumer.consume()
         self.consumer.consume()
 
+    def test_async_produce_thread_exception(self):
+        """Ensure that an exception on a worker thread is raised to the main thread"""
+        topic = self.client.topics[self.topic_name]
+        with self.assertRaises(ValueError):
+            with topic.get_producer() as producer:
+                # get some dummy data into the queue that will cause a crash when flushed
+                # specifically, this tuple causes a crash since its first element is
+                # not a two-tuple
+                producer._produce(("anything", 0))
+        while self.consumer.consume() is not None:
+            time.sleep(.05)
+
 
 if __name__ == "__main__":
     unittest2.main()

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -27,8 +27,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         # produced in a previous test
         payload = uuid4().bytes
 
-        prod = self.client.topics[self.topic_name].get_producer(
-            batch_size=5)
+        prod = self.client.topics[self.topic_name].get_producer()
         prod.produce([payload])
 
         # set a timeout so we don't wait forever if we break producer code

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -27,7 +27,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         # produced in a previous test
         payload = uuid4().bytes
 
-        prod = self.client.topics[self.topic_name].get_producer()
+        prod = self.client.topics[self.topic_name].get_sync_producer()
         prod.produce([payload])
 
         # set a timeout so we don't wait forever if we break producer code
@@ -37,7 +37,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
     def test_async_produce(self):
         payload = uuid4().bytes
 
-        prod = self.client.topics[self.topic_name].get_async_producer()
+        prod = self.client.topics[self.topic_name].get_producer()
         prod.produce([payload])
 
         message = self.consumer.consume()
@@ -46,7 +46,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
     def test_async_produce_context(self):
         payload = uuid4().bytes
 
-        with self.client.topics[self.topic_name].get_async_producer() as producer:
+        with self.client.topics[self.topic_name].get_producer() as producer:
             producer.produce([payload])
 
         message = self.consumer.consume()


### PR DESCRIPTION
This pull request updates the `Producer` to use a thread per broker instead of the main thread for all brokers.

[This code](https://gist.github.com/emmett9001/ef40bac8ce9a160377af) can be used to test this producer's throughput. Here are some [throughput test results with this script](https://gist.github.com/emmett9001/a3a7f0e9f52ac8471912) (how many times per second each producer can return from `produce()`). The old synchronous producer was doing about 4500 messages per second.

Connects to #124.

Todo:
*  [x] Unit test exception raised on worker thread
*  [x] Monitor thread death
*  [x] Abstract thread management logic into the `QueueInfo` class
*  [x] Make `Producer` as small as possible by having it be a special case of `AsyncProducer`
*  [x] Tests