### PR TITLE
Fix Partition's earliest and latest offset methods.

### DIFF
--- a/pykafka/base.py
+++ b/pykafka/base.py
@@ -139,7 +139,7 @@ class BasePartition(object):
         """
         return self._topic
 
-    def latest_available_offsets(self):
+    def latest_available_offset(self):
         """Gets the latest offset for the partition.
 
         :return: Latest offset for the partition.
@@ -147,7 +147,7 @@ class BasePartition(object):
         """
         raise NotImplementedError
 
-    def earliest_available_offsets(self):
+    def earliest_available_offset(self):
         """Gets the earliest offset for the partition.
 
         Due to logfile rotation, this will not always be 0. Instead,

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -99,16 +99,16 @@ class Partition(base.BasePartition):
         request = PartitionOffsetRequest(
             self.topic.name, self.id, offsets_before, max_offsets
         )
-        res = self._leader.request_offsets([request])
+        res = self._leader.request_offset_limits([request])
         return res.topics[self.topic.name][self._id][0]
 
-    def latest_available_offsets(self):
+    def latest_available_offset(self):
         """Get the latest offset for this partition."""
-        return self.fetch_offset_limit(OffsetType.LATEST)[self._id][0]
+        return self.fetch_offset_limit(OffsetType.LATEST)[0]
 
-    def earliest_available_offsets(self):
+    def earliest_available_offset(self):
         """Get the earliest offset for this partition."""
-        return self.fetch_offset_limit(OffsetType.EARLIEST)[self._id][0]
+        return self.fetch_offset_limit(OffsetType.EARLIEST)[0]
 
     def __hash__(self):
         return hash((self.topic, self.id))

--- a/tests/pykafka/test_partition.py
+++ b/tests/pykafka/test_partition.py
@@ -1,0 +1,34 @@
+import unittest2
+
+from pykafka import KafkaClient
+from pykafka.test.utils import get_cluster, stop_cluster
+
+
+class TestPartitionInfo(unittest2.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kafka = get_cluster()
+        cls.topic_name = 'test-data'
+        cls.kafka.create_topic(cls.topic_name, 3, 2)
+        cls.client = KafkaClient(cls.kafka.brokers)
+        cls.producer = cls.client.topics[cls.topic_name].get_producer()
+        cls.total_messages = 99
+        for i in range(cls.total_messages):
+            cls.producer.produce(["message %s" % i])
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_cluster(cls.kafka)
+
+    def test_can_get_earliest_offset(self):
+        partitions = self.client.topics[self.topic_name].partitions
+        for partition in partitions.values():
+            self.assertEqual(0, partition.earliest_available_offset())
+
+    def test_can_get_latest_offset(self):
+        partitions = self.client.topics[self.topic_name].partitions
+        for partition in partitions.values():
+            self.assertTrue(partition.latest_available_offset())
+
+if __name__ == "__main__":
+    unittest2.main()


### PR DESCRIPTION
Looks like this stuff was broken during some refactor.

I also de-pluralized the method name in the interface as a partition only has one earliest or latest offset.