### PR TITLE
[RDY] tests: cherry-picked changes from feature/rdkafka-extension

### DIFF
--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -49,9 +49,7 @@ class TestSimpleConsumer(unittest2.TestCase):
 
             offsets_fetched = {r[0]: r[1].offset
                                for r in consumer.fetch_offsets()}
-            offset_diff = sum(offsets_fetched[i] - offsets_committed[i]
-                              for i in offsets_committed)
-            self.assertEquals(offset_diff, 0)
+            self.assertEquals(offsets_fetched, offsets_committed)
 
     def test_offset_resume(self):
         """Check resumed internal state matches committed offsets"""
@@ -64,9 +62,7 @@ class TestSimpleConsumer(unittest2.TestCase):
         with self._get_simple_consumer(
                 consumer_group='test_offset_resume') as consumer:
             offsets_resumed = self._currently_held_offsets(consumer)
-            offset_diff = sum(offsets_resumed[i] - offsets_committed[i]
-                              for i in offsets_committed)
-            self.assertEquals(offset_diff, 0)
+            self.assertEquals(offsets_resumed, offsets_committed)
 
     @staticmethod
     def _currently_held_offsets(consumer):

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -1,5 +1,5 @@
+from contextlib import contextmanager
 import mock
-import os
 import time
 import unittest2
 
@@ -26,43 +26,52 @@ class TestSimpleConsumer(unittest2.TestCase):
     def tearDownClass(cls):
         stop_cluster(cls.kafka)
 
+    @contextmanager
+    def _get_simple_consumer(self, **kwargs):
+        # Mostly spun out so we can override it in TestRdKafkaSimpleConsumer
+        topic = self.client.topics[self.topic_name]
+        consumer = topic.get_simple_consumer(**kwargs)
+        yield consumer
+        consumer.stop()
+
     def test_consume(self):
-        consumer = self.client.topics[self.topic_name].get_simple_consumer()
-        try:
+        with self._get_simple_consumer() as consumer:
             messages = [consumer.consume() for _ in xrange(1000)]
             self.assertEquals(len(messages), 1000)
-        finally:
-            consumer.stop()
 
     def test_offset_commit(self):
-        consumer = self.client.topics[self.topic_name].get_simple_consumer('test_offset_commit')
-        try:
+        """Check fetched offsets match pre-commit internal state"""
+        with self._get_simple_consumer(
+                consumer_group='test_offset_commit') as consumer:
             [consumer.consume() for _ in xrange(100)]
+            offsets_committed = self._currently_held_offsets(consumer)
             consumer.commit_offsets()
-            res = consumer.fetch_offsets()
-            offset_sum = sum(r[1].offset for r in res if r[1].offset >= 0)
-            self.assertEquals(offset_sum, 99)  # 0-indexed
-        finally:
-            consumer.stop()
 
+            offsets_fetched = {r[0]: r[1].offset
+                               for r in consumer.fetch_offsets()}
+            offset_diff = sum(offsets_fetched[i] - offsets_committed[i]
+                              for i in offsets_committed)
+            self.assertEquals(offset_diff, 0)
 
     def test_offset_resume(self):
-        consumer = self.client.topics[self.topic_name].get_simple_consumer('test_offset_resume')
-        try:
+        """Check resumed internal state matches committed offsets"""
+        with self._get_simple_consumer(
+                consumer_group='test_offset_resume') as consumer:
             [consumer.consume() for _ in xrange(100)]
+            offsets_committed = self._currently_held_offsets(consumer)
             consumer.commit_offsets()
-        finally:
-            consumer.stop()
 
-        consumer = self.client.topics[self.topic_name].get_simple_consumer('test_offset_resume')
-        try:
-            res = consumer.fetch_offsets()
-            offset_sum = sum(p.last_offset_consumed
-                             for p in consumer.partitions
-                             if p.last_offset_consumed >= 0)
-            self.assertEquals(offset_sum, 99)  # 0-indexed
-        finally:
-            consumer.stop()
+        with self._get_simple_consumer(
+                consumer_group='test_offset_resume') as consumer:
+            offsets_resumed = self._currently_held_offsets(consumer)
+            offset_diff = sum(offsets_resumed[i] - offsets_committed[i]
+                              for i in offsets_committed)
+            self.assertEquals(offset_diff, 0)
+
+    @staticmethod
+    def _currently_held_offsets(consumer):
+        return {p.partition.id: p.last_offset_consumed
+                for p in consumer.partitions}
 
 
 class TestOwnedPartition(unittest2.TestCase):


### PR DESCRIPTION
These are the accumulated changes to test_simpleconsumer on the rdkafka
branch at de4b5453910fe903ec51a7d29c13a65445f8ce7f.  There are basically
two changes:

 * The instantiation of a consumer is spun out into a separate method,
   so that this may be overridden (that is, to insert an rdkafka consumer
   instead)
 * The assertions that required that offsets obtained were always on a
   clean cluster, and thus zero-based, have been rewritten (but
   preserving the aim of each test).  This was needed because the tests
   would erratically pass then fail then pass, as the offsets obtained
   through the Offset API would sometimes be stale offsets from a
   previous run or a previous TestCase (I observed both)

Signed-off-by: Yung-Chin Oei <yungchin@yungchin.nl>