### PR TITLE
BalancedConsumer timeout fixes

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -243,7 +243,7 @@ class BalancedConsumer():
         self._zookeeper = KazooClient(zookeeper_connect, timeout=timeout / 1000)
         self._zookeeper.start()
 
-    def _setup_internal_consumer(self):
+    def _setup_internal_consumer(self, start=True):
         """Instantiate an internal SimpleConsumer.
 
         If there is already a SimpleConsumer instance held by this object,
@@ -273,7 +273,8 @@ class BalancedConsumer():
             offsets_channel_backoff_ms=self._offsets_channel_backoff_ms,
             offsets_commit_max_retries=self._offsets_commit_max_retries,
             auto_offset_reset=self._auto_offset_reset,
-            reset_offset_on_start=reset_offset_on_start
+            reset_offset_on_start=reset_offset_on_start,
+            auto_start=start
         )
 
     def _decide_partitions(self, participants):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -121,7 +121,7 @@ class SimpleConsumer(base.BaseSimpleConsumer):
         :type auto_offset_reset: :class:`pykafka.common.OffsetType`
         :param consumer_timeout_ms: Amount of time (in milliseconds) the
             consumer may spend without messages available for consumption
-            before raising an error.
+            before returning None.
         :type consumer_timeout_ms: int
         :param auto_start: Whether the consumer should begin communicating
             with kafka after __init__ is complete. If false, communication

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 import time
 
@@ -38,10 +36,12 @@ class TestBalancedConsumer(unittest2.TestCase):
         cls._mock_consumer, _ = buildMockConsumer(timeout=cls._consumer_timeout)
 
     def test_consume_returns(self):
+        """Ensure that consume() returns in the amount of time it's supposed to
+        """
         self._mock_consumer._setup_internal_consumer(start=False)
         start = time.time()
         self._mock_consumer.consume()
-        self.assertTrue(time.time() - start >= self._consumer_timeout / 1000)
+        self.assertEqual(int(time.time() - start), int(self._consumer_timeout / 1000))
 
     def test_decide_partitions(self):
         """Test partition assignment for a number of partitions/consumers."""


### PR DESCRIPTION
This pull request fixes a bug in `BalancedConsumer` detailed in [this issue](https://github.com/Parsely/pykafka/issues/190). Specifically, the issue is that a call to `consume(block=True)` on a `BalancedConsumer` consuming an empty topic with `consumer_timeout_ms > 0` never returns. This pull request fixes the issue by using the old timeout logic from `SimpleConsumer` in `BalancedConsumer` to ensure that the `consume` call returns if no messages are received after the specified timeout.

We never see this issue in production at Parsely because, although our timeout is greater than zero and we use `block=True`, our topic is never empty.

It's ok to use the naive long-polling method of waiting on messages in `BalancedConsumer` because the internal `SimpleConsumer` instance is smart about its CPU usage. Comparatively, a small amount of time is spent in the `BalancedConsumer.consume` loop, so it should not have a noticeably negative effect on resource usage.

This pull request also adds a test case that ensures that `consume()` returns when it's supposed to. The test fails on current master and passes on this branch.