### PR TITLE
public interface for offset resetting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,4 +103,4 @@ Support
 If you need help using PyKafka or have found a bug, please open a `github issue`_ or use the `Google Group`_.
 
 .. _github issue: https://github.com/Parsely/pykafka/issues
-.. _Google Group: pykafka-user@googlegroups.com
+.. _Google Group: https://groups.google.com/forum/#!forum/pykafka-user

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -209,6 +209,14 @@ class BalancedConsumer():
     def partitions(self):
         return self._consumer.partitions if self._consumer else None
 
+    @property
+    def held_offsets(self):
+        """Return a map from partition id to held offset for each partition"""
+        if not self._consumer:
+            return None
+        return dict((p.partition.id, p.last_offset_consumed)
+                    for p in self._consumer._partitions_by_id.itervalues())
+
     def start(self):
         """Open connections and join a cluster."""
         if self._zookeeper is None:

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -515,11 +515,11 @@ class BalancedConsumer():
         Issue an OffsetRequest for each partition and set the appropriate
         returned offset in the OwnedPartition
 
-        :param partitions: (`partition`, `offset`) pairs to reset
+        :param partition_offsets: (`partition`, `offset`) pairs to reset
             where `partition` is the partition for which to reset the offset
             and `offset` is the new offset the partition should have
-        :type partitions: Iterable of
-            (:class:`pykafka.simpleconsumer.OwnedPartition`, int)
+        :type partition_offsets: Iterable of
+            (:class:`pykafka.partition.Partition`, int)
         """
         if not self._consumer:
             raise ConsumerStoppedException("Internal consumer is stopped")

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -207,7 +207,7 @@ class BalancedConsumer():
 
     @property
     def partitions(self):
-        return self._partitions
+        return self._consumer.partitions if self._consumer else None
 
     def start(self):
         """Open connections and join a cluster."""

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -509,7 +509,7 @@ class BalancedConsumer():
         log.debug("Rebalance triggered by topic change")
         self._rebalance()
 
-    def reset_offsets(self, partitions=None):
+    def reset_offsets(self, partitions=None, flush=True):
         """Reset offsets for the specified partitions
 
         Issue an OffsetRequest for each partition and set the appropriate
@@ -520,10 +520,13 @@ class BalancedConsumer():
             and `offset` is the new offset the partition should have
         :type partitions: Iterable of
             (:class:`pykafka.simpleconsumer.OwnedPartition`, int)
+        :param flush: Whether to flush the internal message queues before
+            resetting offsets
+        :type flush: bool
         """
         if not self._consumer:
             raise ConsumerStoppedException("Internal consumer is stopped")
-        self._consumer.reset_offsets(partitions=partitions)
+        self._consumer.reset_offsets(partitions=partitions, flush=flush)
 
     def consume(self, block=True):
         """Get one message from the consumer

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -509,7 +509,7 @@ class BalancedConsumer():
         log.debug("Rebalance triggered by topic change")
         self._rebalance()
 
-    def reset_offsets(self, partitions=None):
+    def reset_offsets(self, partition_offsets=None):
         """Reset offsets for the specified partitions
 
         Issue an OffsetRequest for each partition and set the appropriate
@@ -523,7 +523,7 @@ class BalancedConsumer():
         """
         if not self._consumer:
             raise ConsumerStoppedException("Internal consumer is stopped")
-        self._consumer.reset_offsets(partitions=partitions)
+        self._consumer.reset_offsets(partition_offsets=partition_offsets)
 
     def consume(self, block=True):
         """Get one message from the consumer

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -509,6 +509,22 @@ class BalancedConsumer():
         log.debug("Rebalance triggered by topic change")
         self._rebalance()
 
+    def reset_offsets(self, partitions=None):
+        """Reset offsets for the specified partitions
+
+        Issue an OffsetRequest for each partition and set the appropriate
+        returned offset in the OwnedPartition
+
+        :param partitions: (`partition`, `offset`) pairs to reset
+            where `partition` is the partition for which to reset the offset
+            and `offset` is the new offset the partition should have
+        :type partitions: Iterable of
+            (:class:`pykafka.simpleconsumer.OwnedPartition`, int)
+        """
+        if not self._consumer:
+            raise ConsumerStoppedException("Internal consumer is stopped")
+        self._consumer.reset_offsets(partitions=partitions)
+
     def consume(self, block=True):
         """Get one message from the consumer
 

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -509,7 +509,7 @@ class BalancedConsumer():
         log.debug("Rebalance triggered by topic change")
         self._rebalance()
 
-    def reset_offsets(self, partitions=None, flush=True):
+    def reset_offsets(self, partitions=None):
         """Reset offsets for the specified partitions
 
         Issue an OffsetRequest for each partition and set the appropriate
@@ -520,13 +520,10 @@ class BalancedConsumer():
             and `offset` is the new offset the partition should have
         :type partitions: Iterable of
             (:class:`pykafka.simpleconsumer.OwnedPartition`, int)
-        :param flush: Whether to flush the internal message queues before
-            resetting offsets
-        :type flush: bool
         """
         if not self._consumer:
             raise ConsumerStoppedException("Internal consumer is stopped")
-        self._consumer.reset_offsets(partitions=partitions, flush=flush)
+        self._consumer.reset_offsets(partitions=partitions)
 
     def consume(self, block=True):
         """Get one message from the consumer

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -520,10 +520,10 @@ class SimpleConsumer():
 
                 if 0 in parts_by_error:
                     parts_by_error.pop(0)
-                partitions = []
-                partitions.extend(
-                    [part for errcode, parts in parts_by_error.iteritems()
-                     for part in parts])
+                owned_partition_offsets = dict(
+                    (part, owned_partition_offsets[part])
+                    for errcode, parts in parts_by_error.iteritems()
+                    for part, _ in parts)
 
             # release all locks to allow fetching
             for errcode, owned_partitions in parts_by_error.iteritems():

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -194,8 +194,6 @@ class SimpleConsumer():
         # Figure out which offset wer're starting on
         if self._reset_offset_on_start:
             self.reset_offsets()
-            # make sure the reset is saved in kafka before it can rebalance
-            self.commit_offsets()
         elif self._consumer_group is not None:
             self.fetch_offsets()
 
@@ -484,6 +482,8 @@ class SimpleConsumer():
 
             if len(parts_by_error) == 1 and 0 in parts_by_error:
                 break
+
+        self.commit_offsets()
 
     def fetch(self):
         """Fetch new messages for all partitions

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -30,7 +30,7 @@ from .utils.compat import Semaphore
 from .exceptions import (OffsetOutOfRangeError, UnknownTopicOrPartition,
                          OffsetMetadataTooLarge, OffsetsLoadInProgress,
                          NotCoordinatorForConsumer, SocketDisconnectedError,
-                         ConsumerStoppedException, ERROR_CODES)
+                         ConsumerStoppedException, KafkaException, ERROR_CODES)
 from .protocol import (PartitionFetchRequest, PartitionOffsetCommitRequest,
                        PartitionOffsetFetchRequest, PartitionOffsetRequest)
 from .utils.error_handlers import handle_partition_responses, raise_error
@@ -429,8 +429,10 @@ class SimpleConsumer():
                     # so account for this here by passing offset - 1
                     owned_partition.set_offset(new_offset - 1)
                 else:
-                    log.warning("Offset reset for partition {} failed.".format(
-                                owned_partition.partition.id))
+                    msg = "Offset reset for partition {} failed.".format(
+                        owned_partition.partition.id)
+                    log.warning(msg)
+                    raise KafkaException(msg)
                 # release locks on succeeded partitions to allow fetching
                 # to resume
                 owned_partition.fetch_lock.release()

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -239,6 +239,12 @@ class SimpleConsumer():
         return dict((id_, partition.partition)
                     for id_, partition in self._partitions_by_id.iteritems())
 
+    @property
+    def held_offsets(self):
+        """Return a map from partition id to held offset for each partition"""
+        return dict((p.partition.id, p.last_offset_consumed)
+                    for p in self._partitions_by_id.itervalues())
+
     def __del__(self):
         """Stop consumption and workers when object is deleted"""
         self.stop()

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -409,7 +409,7 @@ class SimpleConsumer():
             to_retry.extend(parts_by_error.get(NotCoordinatorForConsumer.ERROR_CODE, []))
             reqs = [p.build_offset_fetch_request() for p, _ in to_retry]
 
-    def reset_offsets(self, partitions=None, flush=True):
+    def reset_offsets(self, partitions=None):
         """Reset offsets for the specified partitions
 
         Issue an OffsetRequest for each partition and set the appropriate
@@ -420,9 +420,6 @@ class SimpleConsumer():
             and `offset` is the new offset the partition should have
         :type partitions: Iterable of
             (:class:`pykafka.simpleconsumer.OwnedPartition`, int)
-        :param flush: Whether to flush the internal message queues before
-            resetting offsets
-        :type flush: bool
         """
         def _handle_success(parts):
             for owned_partition, pres in parts:
@@ -449,8 +446,7 @@ class SimpleConsumer():
                 if partition.fetch_lock.acquire(True):
                     # empty the queue for this partition to avoid sending
                     # emitting messages from the old offset
-                    if flush:
-                        partition.flush()
+                    partition.flush()
                     by_leader[partition.partition.leader].append((partition, offset))
 
             # get valid offset ranges for each partition

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -209,8 +209,7 @@ class SimpleConsumer():
         def _handle_OffsetOutOfRangeError(parts):
             self.reset_offsets(
                 partitions=[(owned_partition, self._auto_offset_reset)
-                            for owned_partition, pres in parts],
-                flush=False
+                            for owned_partition, pres in parts]
             )
 
         def _handle_NotCoordinatorForConsumer(parts):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -316,7 +316,8 @@ class SimpleConsumer():
         if (time.time() - self._last_auto_commit) * 1000.0 >= self._auto_commit_interval_ms:
             log.info("Autocommitting consumer offset for consumer group %s and topic %s",
                      self._consumer_group, self._topic.name)
-            self.commit_offsets()
+            if self._consumer_group is not None:
+                self.commit_offsets()
             self._last_auto_commit = time.time()
 
     def commit_offsets(self):
@@ -483,7 +484,8 @@ class SimpleConsumer():
             if len(parts_by_error) == 1 and 0 in parts_by_error:
                 break
 
-        self.commit_offsets()
+        if self._consumer_group is not None:
+            self.commit_offsets()
 
     def fetch(self):
         """Fetch new messages for all partitions

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -538,12 +538,16 @@ class OwnedPartition(object):
         self._messages_arrived = semaphore
         self.last_offset_consumed = 0
         self.next_offset = 0
-        self.lock = threading.Lock()
+        self.fetch_lock = threading.Lock()
 
     @property
     def message_count(self):
         """Count of messages currently in this partition's internal queue"""
         return self._messages.qsize()
+
+    def flush(self):
+        self._messages = Queue()
+        log.info("Flushed queue for partition %d", self.partition.id)
 
     def set_offset(self, last_offset_consumed):
         """Set the internal offset counters
@@ -552,6 +556,8 @@ class OwnedPartition(object):
             partition
         :type last_offset_consumed: int
         """
+        log.debug("Set offset for partition %d to %d",
+                  self.partition.id, last_offset_consumed)
         self.last_offset_consumed = last_offset_consumed
         self.next_offset = last_offset_consumed + 1
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -577,8 +577,6 @@ class OwnedPartition(object):
             partition
         :type last_offset_consumed: int
         """
-        log.debug("Set offset for partition %d to %d",
-                  self.partition.id, last_offset_consumed)
         self.last_offset_consumed = last_offset_consumed
         self.next_offset = last_offset_consumed + 1
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -555,18 +555,21 @@ class OwnedPartition(object):
         self.last_offset_consumed = last_offset_consumed
         self.next_offset = last_offset_consumed + 1
 
-    def build_offset_request(self, auto_offset_reset):
+    def build_offset_request(self, new_offset):
         """Create a :class:`pykafka.protocol.PartitionOffsetRequest` for this
             partition
 
-        :param auto_offset_reset: What to do if an offset is out of range. This
+        :param new_offset: What to do if an offset is out of range. This
             setting indicates how to reset the consumer's internal offset
             counter when an OffsetOutOfRangeError is encountered.
-        :type auto_offset_reset: :class:`pykafka.common.OffsetType`
+            There are two special values. Specify -1 to receive the latest
+            offset (i.e. the offset of the next coming message) and -2 to
+            receive the earliest available offset.
+        :type new_offset: :class:`pykafka.common.OffsetType` or int
         """
         return PartitionOffsetRequest(
             self.partition.topic.name, self.partition.id,
-            auto_offset_reset, 1)
+            new_offset, 1)
 
     def build_fetch_request(self, max_bytes):
         """Create a :class:`pykafka.protocol.FetchPartitionRequest` for this

--- a/pykafka/utils/error_handlers.py
+++ b/pykafka/utils/error_handlers.py
@@ -27,12 +27,15 @@ def handle_partition_responses(error_handlers,
                                partitions_by_id=None):
     """Call the appropriate handler for each errored partition
 
-    :param response: a Response object containing partition responses
-    :type response: :class:`pykafka.protocol.Response`
-    :param success_handler: function to call for successful partitions
-    :type success_handler: callable accepting an iterable of partition responses
     :param error_handlers: mapping of error code to handler
     :type error_handlers: dict {int: callable(parts)}
+    :param parts_by_error: a dict of partitions grouped by error code
+    :type parts_by_error: dict
+        {int: iterable(:class:`pykafka.simpleconsumer.OwnedPartition`)}
+    :param success_handler: function to call for successful partitions
+    :type success_handler: callable accepting an iterable of partition responses
+    :param response: a Response object containing partition responses
+    :type response: :class:`pykafka.protocol.Response`
     :param partitions_by_id: a dict mapping partition ids to OwnedPartition
         instances
     :type partitions_by_id: dict
@@ -53,6 +56,15 @@ def handle_partition_responses(error_handlers,
 
 
 def build_parts_by_error(response, partitions_by_id):
+    """Separate the partitions from a response by their error code
+
+    :param response: a Response object containing partition responses
+    :type response: :class:`pykafka.protocol.Response`
+    :param partitions_by_id: a dict mapping partition ids to OwnedPartition
+        instances
+    :type partitions_by_id: dict
+        {int: :class:`pykafka.simpleconsumer.OwnedPartition`}
+    """
     # group partition responses by error code
     parts_by_error = defaultdict(list)
     for topic_name in response.topics.keys():

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -66,7 +66,7 @@ class TestSimpleConsumer(unittest2.TestCase):
     @staticmethod
     def _currently_held_offsets(consumer):
         return dict((p.partition.id, p.last_offset_consumed)
-                    for p in consumer.partitions)
+                    for p in consumer._partitions.itervalues())
 
 
 class TestOwnedPartition(unittest2.TestCase):


### PR DESCRIPTION
This pull request adds a public interface to the consumers that allows client code to set the current partition offsets to whatever they choose. Previously, this had to be done via a semi-public undocumented interface as detailed in [this issue](https://github.com/Parsely/pykafka/issues/187).

Given these changes, the new workflow for specifying offsets from which to consume looks like this:
```python
consumer = topic.get_simple_consumer(consumer_group="testgroup")
partition_offset_pairs = [(p, get_offset_for_partition(p)) for p in consumer.partitions.itervalues()]
consumer.reset_offsets(partition_offsets=partition_offset_pairs)
```
This pull request also ties `reset_offsets` to the `fetch` locking mechanism so that a partition can never be fetching and resetting its offsets at the same time. This makes the unlocking logic at the end of `fetch()` notably more complicated, since one of its error conditions involves calling `reset_offsets`.

**The following has been resolved in this pull request**
~~The only issue I see with this method is that the consumer has a chance to start fetching messages between `get_simple_consumer` and `reset_offsets`. To get around this,  we could accept the `partition_offset_pairs` in `get_simple_consumer`, but that would require some way to obtain a list of partitions before actually instantiating a consumer. This sounds like a road I'd rather not go down, so the question is: how bad is it that it's impossible to start the consumer at an arbitrary offset that's not the head or tail of the partition? My gut tells me it doesn't matter and this solution is ok.~~
Let me know what you think, @kbourgoin and @yungchin.