### PR TITLE
Avoid test_producer stalling randomly

### DIFF
--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -25,7 +25,8 @@ class ProducerIntegrationTests(unittest2.TestCase):
             # produced in a previous test
             payload = uuid4().bytes
 
-            prod = self.client.topics[self.topic_name].get_producer(batch_size=5)
+            prod = self.client.topics[self.topic_name].get_producer(
+                batch_size=5)
             prod.produce([payload])
 
             # set a timeout so we don't wait forever if we break producer code

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -29,10 +29,8 @@ class ProducerIntegrationTests(unittest2.TestCase):
             prod.produce([payload])
 
             # set a timeout so we don't wait forever if we break producer code
-            consumer = self.client.topics[self.topic_name].get_balanced_consumer(
-                'test_consume',
-                consumer_timeout_ms=1000,
-                zookeeper_connect=self.kafka.zookeeper)
+            consumer = self.client.topics[self.topic_name].get_simple_consumer(
+                consumer_timeout_ms=1000)
             message = consumer.consume()
             self.assertTrue(message.value == payload)
         finally:

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -1,4 +1,5 @@
 import unittest2
+from uuid import uuid4
 
 from pykafka import KafkaClient
 from pykafka.test.utils import get_cluster, stop_cluster
@@ -20,12 +21,20 @@ class ProducerIntegrationTests(unittest2.TestCase):
 
     def test_produce(self):
         try:
-            prod = self.client.topics[self.topic_name].get_producer(batch_size=5)
-            prod.produce(['msg test'])
+            # unique bytes, just to be absolutely sure we're not fetching data
+            # produced in a previous test
+            payload = uuid4().bytes
 
-            consumer = self.client.topics[self.topic_name].get_balanced_consumer('test_consume', zookeeper_connect=self.kafka.zookeeper)
-            messages = [consumer.consume() for i in xrange(1)]
-            self.assertTrue(len(messages) == 1)
+            prod = self.client.topics[self.topic_name].get_producer(batch_size=5)
+            prod.produce([payload])
+
+            # set a timeout so we don't wait forever if we break producer code
+            consumer = self.client.topics[self.topic_name].get_balanced_consumer(
+                'test_consume',
+                consumer_timeout_ms=1000,
+                zookeeper_connect=self.kafka.zookeeper)
+            message = consumer.consume()
+            self.assertTrue(message.value == payload)
         finally:
             consumer.stop()
 


### PR DESCRIPTION
This works around an issue mentioned in, but probably not the subject of, #189. Details in commit messages.