### PR TITLE
consistent reset_offsets

### DIFF
--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -45,6 +45,11 @@ class NoMessagesConsumedError(KafkaException):
     pass
 
 
+class OffsetRequestFailedError(KafkaException):
+    """Indicates that OffsetRequests for offset resetting failed more times than the configured maximum"""
+    pass
+
+
 class PartitionOwnedError(KafkaException):
     """Indicates a given partition is still owned in Zookeeper."""
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -421,7 +421,7 @@ class SimpleConsumer():
         """Reset offsets for the specified partitions
 
         Issue an OffsetRequest for each partition and set the appropriate
-        returned offset in the OwnedPartition
+        returned offset in the consumer's internal offset counter.
 
         :param partition_offsets: (`partition`, `timestamp_or_offset`) pairs to
             reset where `partition` is the partition for which to reset the offset

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -527,6 +527,14 @@ class SimpleConsumer():
             for errcode, owned_partitions in parts_by_error.iteritems():
                 if errcode != 0:
                     for owned_partition in owned_partitions:
+                        # set internal counter appropriately to avoid possibly
+                        # leaving it in a state inconsistent with the given
+                        # offset
+                        given_offset = owned_partition_offsets[owned_partition]
+                        # don't reset counter to a magic value, only to a real
+                        # offset
+                        if given_offset != self._auto_offset_reset:
+                            owned_partition.set_offset(given_offset)
                         owned_partition.fetch_lock.release()
 
             if len(parts_by_error) == 1 and 0 in parts_by_error:

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -523,7 +523,6 @@ class SimpleConsumer():
                     for errcode, parts in parts_by_error.iteritems()
                     for part, _ in parts)
 
-            # release all locks to allow fetching
             for errcode, owned_partitions in parts_by_error.iteritems():
                 if errcode != 0:
                     for owned_partition in owned_partitions:
@@ -535,6 +534,7 @@ class SimpleConsumer():
                         # offset
                         if given_offset != self._auto_offset_reset:
                             owned_partition.set_offset(given_offset)
+                        # release all locks to allow fetching
                         owned_partition.fetch_lock.release()
 
             if len(parts_by_error) == 1 and 0 in parts_by_error:

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -451,8 +451,6 @@ class SimpleConsumer():
                     # following:
                     #   returns an empty array in pres.offset
                     #   returns error code 0
-                    #   sets the specified number as the offset in its internal
-                    #       store
                     # Here, we detect this case and set the consumer's internal
                     # offset to that value. Thus, the next fetch request will
                     # attempt to fetch from that offset. If it succeeds, all is


### PR DESCRIPTION
This pull request ensures that the offsets supplied during a call to `reset_offsets` will be saved to the consumer's internal counters even in cases where the maximum number of retries was reached.