### PR TITLE
Reset offsets for all brokers in simpleconsumer.py

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -509,7 +509,7 @@ class SimpleConsumer():
                     partitions_by_id=self._partitions_by_id)
 
                 if len(parts_by_error) == 1 and 0 in parts_by_error:
-                    break
+                    continue
                 log.error("Error resetting offsets for topic %s (errors: %s)",
                           self._topic.name,
                           dict((ERROR_CODES[err], [op.partition.id for op, _ in parts])


### PR DESCRIPTION
Breaking here prevents the rest of the by_leader dict from being processed. Since we've successfully read the offsets of the current broker, we should continue the iteration instead.