### PR TITLE
Tests for SimpleConsumer.reset_offsets

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -497,9 +497,6 @@ class SimpleConsumer():
                     partition.flush()
                     by_leader[partition.partition.leader].append((partition, offset))
 
-            # reset this dict to prepare it for next retry
-            owned_partition_offsets = {}
-
             # get valid offset ranges for each partition
             for broker, offsets in by_leader.iteritems():
                 reqs = [owned_partition.build_offset_request(offset)
@@ -522,12 +519,10 @@ class SimpleConsumer():
 
                 if 0 in parts_by_error:
                     parts_by_error.pop(0)
-                errored_partitions = dict(
+                owned_partition_offsets = dict(
                     (part, owned_partition_offsets[part])
                     for errcode, parts in parts_by_error.iteritems()
                     for part, _ in parts)
-                owned_partition_offsets = dict(errored_partitions.items() +
-                                               owned_partition_offsets.items())
 
             for errcode, owned_partitions in parts_by_error.iteritems():
                 if errcode != 0:

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -44,7 +44,7 @@ class TestSimpleConsumer(unittest2.TestCase):
         with self._get_simple_consumer(
                 consumer_group='test_offset_commit') as consumer:
             [consumer.consume() for _ in xrange(100)]
-            offsets_committed = self._currently_held_offsets(consumer)
+            offsets_committed = consumer.held_offsets
             consumer.commit_offsets()
 
             offsets_fetched = dict((r[0], r[1].offset)
@@ -56,18 +56,12 @@ class TestSimpleConsumer(unittest2.TestCase):
         with self._get_simple_consumer(
                 consumer_group='test_offset_resume') as consumer:
             [consumer.consume() for _ in xrange(100)]
-            offsets_committed = self._currently_held_offsets(consumer)
+            offsets_committed = consumer.held_offsets
             consumer.commit_offsets()
 
         with self._get_simple_consumer(
                 consumer_group='test_offset_resume') as consumer:
-            offsets_resumed = self._currently_held_offsets(consumer)
-            self.assertEquals(offsets_resumed, offsets_committed)
-
-    @staticmethod
-    def _currently_held_offsets(consumer):
-        return dict((p.partition.id, p.last_offset_consumed)
-                    for p in consumer._partitions.itervalues())
+            self.assertEquals(consumer.held_offsets, offsets_committed)
 
 
 class TestOwnedPartition(unittest2.TestCase):

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -119,7 +119,11 @@ class TestSimpleConsumer(unittest2.TestCase):
             invalid_offset = latest_offset + 5
             consumer.reset_offsets(
                 [(consumer.partitions[part_id], invalid_offset)])
-            time.sleep(1.)  # ugly, but we must let the fetcher thread work
+            # SimpleConsumer's fetcher thread will detect the invalid offset
+            # and reset it immediately.  RdKafkaSimpleConsumer however will
+            # only get to write the valid offset upon a call to consume():
+            time.sleep(.5)  # wait for fetcher to handle OffsetOutOfRangeError
+            msg = consumer.consume(block=False)
             self.assertEqual(consumer.held_offsets[part_id], latest_offset)
 
 

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import mock
 import unittest2
+from uuid import uuid4
 
 from pykafka import KafkaClient
 from pykafka.simpleconsumer import OwnedPartition
@@ -13,7 +14,7 @@ class TestSimpleConsumer(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kafka = get_cluster()
-        cls.topic_name = 'test-data'
+        cls.topic_name = uuid4().hex
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.kafka.produce_messages(
             cls.topic_name,


### PR DESCRIPTION
This adds tests for reset_offsets (which I'm also looking to use to ensure the implementation of reset_offsets in #176 will be conformant), and fixes some issues with that method which I encountered in the course of writing tests.