### PR TITLE
check if the internal consumer is running.

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -594,6 +594,9 @@ class BalancedConsumer():
                 # don't raise the exception if we're rebalancing
                 if self._rebalancing_lock.locked():
                     continue
+                # rebalancing has been finished
+                if self._consumer.running:
+                    continue
                 raise
             if message:
                 self._last_message_time = time.time()

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -591,11 +591,10 @@ class BalancedConsumer():
             try:
                 message = self._consumer.consume(block=block)
             except ConsumerStoppedException:
-                # don't raise the exception if we're rebalancing
-                if self._rebalancing_lock.locked():
-                    continue
-                # rebalancing has been finished
-                if self._consumer.running:
+                # don't raise the exception if we're rebalancing,
+                # or rebalancing has been finished and the internal consumer
+                # is running.
+                if self._rebalancing_lock.locked() or self._consumer.running:
                     continue
                 raise
             if message:


### PR DESCRIPTION
The rebalance may have been finished before we check if we are rebalancing. So we check if the internal consumer is running before we raise an exception.