### PR TITLE
listen kazoo state changed

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -594,6 +594,9 @@ class BalancedConsumer():
                 # don't raise the exception if we're rebalancing
                 if self._rebalancing_lock.locked():
                     continue
+                # rebalancing has been finished
+                if self._consumer.running:
+                    continue
                 raise
             if message:
                 self._last_message_time = time.time()

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -322,6 +322,9 @@ class SimpleConsumer():
             else:
                 timeout = 1.0
 
+        if not self._running:
+            raise ConsumerStoppedException()
+
         while True:
             if self._messages_arrived.acquire(blocking=block, timeout=timeout):
                 # by passing through this semaphore, we know that at


### PR DESCRIPTION
To avoid multiple consumers to consume the same partition. I add a strict testing on the connection of zookeeper. I think a connection to zookeeper is re-connected only if a rebalancing has been finished.
BTW, if the id of a consumer is missing in zookeeper, its registry of owned partitions should be missing too. In this condition, we should not call self._remove_partitions().