### PR TITLE
Allow KafkaClient to configure source_address

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -46,7 +46,9 @@ class Broker():
                  handler,
                  socket_timeout_ms,
                  offsets_channel_socket_timeout_ms,
-                 buffer_size=1024 * 1024):
+                 buffer_size=1024 * 1024,
+                 source_host='',
+                 source_port=0):
         """Create a Broker instance.
 
         :param id_: The id number of this broker
@@ -67,12 +69,20 @@ class Broker():
         :param buffer_size: The size (bytes) of the internal buffer used to
             receive network responses
         :type buffer_size: int
+        :param source_host: The host portion of the source address for
+            socket connections
+        :type source_host: str
+        :param source_port: The port portion of the source address for
+            socket connections
+        :type source_port: int
         """
         self._connection = None
         self._offsets_channel_connection = None
         self._id = int(id_)
         self._host = host
         self._port = port
+        self._source_host = source_host
+        self._source_port = source_port
         self._handler = handler
         self._req_handler = None
         self._offsets_channel_req_handler = None
@@ -97,7 +107,9 @@ class Broker():
                       handler,
                       socket_timeout_ms,
                       offsets_channel_socket_timeout_ms,
-                      buffer_size=64 * 1024):
+                      buffer_size=64 * 1024,
+                      source_host='',
+                      source_port=0):
         """Create a Broker using BrokerMetadata
 
         :param metadata: Metadata that describes the broker.
@@ -113,11 +125,19 @@ class Broker():
         :param buffer_size: The size (bytes) of the internal buffer used to
             receive network responses
         :type buffer_size: int
+        :param source_host: The host portion of the source address for
+            socket connections
+        :type source_host: str
+        :param source_port: The port portion of the source address for
+            socket connections
+        :type source_port: int
         """
         return cls(metadata.id, metadata.host,
                    metadata.port, handler, socket_timeout_ms,
                    offsets_channel_socket_timeout_ms,
-                   buffer_size=buffer_size)
+                   buffer_size=buffer_size,
+                   source_host=source_host,
+                   source_port=source_port)
 
     @property
     def connected(self):
@@ -174,7 +194,9 @@ class Broker():
         :class:`pykafka.handlers.RequestHandler` for this broker
         """
         self._connection = BrokerConnection(self.host, self.port,
-                                            self._buffer_size)
+                                            buffer_size=self._buffer_size,
+                                            source_host=self._source_host,
+                                            source_port=self._source_port)
         self._connection.connect(self._socket_timeout_ms)
         self._req_handler = RequestHandler(self._handler, self._connection)
         self._req_handler.start()
@@ -186,8 +208,9 @@ class Broker():
         :class:`pykafka.handlers.RequestHandler` for this broker's offsets
         channel
         """
-        self._offsets_channel_connection = BrokerConnection(self.host, self.port,
-                                                            self._buffer_size)
+        self._offsets_channel_connection = BrokerConnection(
+            self.host, self.port, buffer_size=self._buffer_size,
+            source_host=self._source_host, source_port=self._source_port)
         self._offsets_channel_connection.connect(self._offsets_channel_socket_timeout_ms)
         self._offsets_channel_req_handler = RequestHandler(
             self._handler, self._offsets_channel_connection

--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -41,7 +41,8 @@ class KafkaClient(object):
                  socket_timeout_ms=30 * 1000,
                  offsets_channel_socket_timeout_ms=10 * 1000,
                  ignore_rdkafka=False,
-                 exclude_internal_topics=True):
+                 exclude_internal_topics=True,
+                 source_address=''):
         """Create a connection to a Kafka cluster.
 
         :param hosts: Comma-separated list of kafka hosts to used to connect.
@@ -60,8 +61,11 @@ class KafkaClient(object):
         :param exclude_internal_topics: Whether messages from internal topics
             (specifically, the offsets topic) should be exposed to the consumer.
         :type exclude_internal_topics: bool
+        :param source_address: The source address for socket connections
+        :type source_address: str `'host:port'`
         """
         self._seed_hosts = hosts
+        self._source_address = source_address
         self._socket_timeout_ms = socket_timeout_ms
         self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._handler = None if use_greenlets else handlers.ThreadingHandler()
@@ -75,7 +79,8 @@ class KafkaClient(object):
                 self._handler,
                 socket_timeout_ms=self._socket_timeout_ms,
                 offsets_channel_socket_timeout_ms=self._offsets_channel_socket_timeout_ms,
-                exclude_internal_topics=exclude_internal_topics
+                exclude_internal_topics=exclude_internal_topics,
+                source_address=self._source_address
             )
         self.brokers = self.cluster.brokers
         self.topics = self.cluster.topics

--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -45,6 +45,9 @@ class KafkaClient(object):
                  source_address=''):
         """Create a connection to a Kafka cluster.
 
+        Documentation for source_address can be found at
+        https://docs.python.org/2/library/socket.html#socket.create_connection
+
         :param hosts: Comma-separated list of kafka hosts to used to connect.
         :type hosts: str
         :param use_greenlets: If True, use gevent instead of threading.

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -83,7 +83,8 @@ class Cluster(object):
                  handler,
                  socket_timeout_ms=30 * 1000,
                  offsets_channel_socket_timeout_ms=10 * 1000,
-                 exclude_internal_topics=True):
+                 exclude_internal_topics=True,
+                 source_address=''):
         """Create a new Cluster instance.
 
         :param hosts: Comma-separated list of kafka hosts to used to connect.
@@ -100,6 +101,8 @@ class Cluster(object):
         :param exclude_internal_topics: Whether messages from internal topics
             (specifically, the offsets topic) should be exposed to consumers.
         :type exclude_internal_topics: bool
+        :param source_address: The source address for socket connections
+        :type source_address: str `'host:port'`
         """
         self._seed_hosts = hosts
         self._socket_timeout_ms = socket_timeout_ms
@@ -108,6 +111,11 @@ class Cluster(object):
         self._brokers = {}
         self._topics = TopicDict(self)
         self._exclude_internal_topics = exclude_internal_topics
+        self._source_address = source_address
+        self._source_host = self._source_address.split(':')[0]
+        self._source_port = 0
+        if ':' in self._source_address:
+            self._source_port = int(self._source_address.split(':')[1])
         self.update()
 
     def __repr__(self):
@@ -150,7 +158,9 @@ class Cluster(object):
                     broker = Broker(-1, h, p, self._handler,
                                     self._socket_timeout_ms,
                                     self._offsets_channel_socket_timeout_ms,
-                                    buffer_size=1024 * 1024)
+                                    buffer_size=1024 * 1024,
+                                    source_host=self._source_host,
+                                    source_port=self._source_port)
                     response = broker.request_metadata()
                     if response is not None:
                         return response
@@ -184,7 +194,9 @@ class Cluster(object):
                 self._brokers[id_] = Broker.from_metadata(
                     meta, self._handler, self._socket_timeout_ms,
                     self._offsets_channel_socket_timeout_ms,
-                    buffer_size=1024 * 1024
+                    buffer_size=1024 * 1024,
+                    source_host=self._source_host,
+                    source_port=self._source_port
                 )
             else:
                 broker = self._brokers[id_]

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -34,7 +34,12 @@ class BrokerConnection(object):
     and handles the sending and receiving of data that conform to the
     kafka binary protocol over that socket.
     """
-    def __init__(self, host, port, buffer_size=1024 * 1024):
+    def __init__(self,
+                 host,
+                 port,
+                 buffer_size=1024 * 1024,
+                 source_host='',
+                 source_port=0):
         """Initialize a socket connection to Kafka.
 
         :param host: The host to which to connect
@@ -44,11 +49,19 @@ class BrokerConnection(object):
         :param buffer_size: The size (in bytes) of the buffer in which to
             hold response data.
         :type buffer_size: int
+        :param source_host: The host portion of the source address for
+            the socket connection
+        :type source_host: str
+        :param source_port: The port portion of the source address for
+            the socket connection
+        :type source_port: int
         """
         self._buff = bytearray(buffer_size)
         self.host = host
         self.port = port
         self._socket = None
+        self.source_host = source_host
+        self.source_port = source_port
 
     def __del__(self):
         """Close this connection when the object is deleted."""
@@ -63,7 +76,8 @@ class BrokerConnection(object):
         """Connect to the broker."""
         self._socket = socket.create_connection(
             (self.host, self.port),
-            timeout=timeout / 1000
+            timeout / 1000,
+            self.source_host, self.source_port
         )
 
     def disconnect(self):

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -77,7 +77,7 @@ class BrokerConnection(object):
         self._socket = socket.create_connection(
             (self.host, self.port),
             timeout / 1000,
-            self.source_host, self.source_port
+            (self.source_host, self.source_port)
         )
 
     def disconnect(self):


### PR DESCRIPTION
This pull request adds a kwarg `source_address` to `KafkaClient`. This is used in `socket.create_connection` to set the source of the connection.

Related to #219 