### PR TITLE
Don't swallow errors when first connecting.

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -164,12 +164,12 @@ class Cluster(object):
                     response = broker.request_metadata()
                     if response is not None:
                         return response
-                except:
-                    log.exception('Unable to connect to broker %s',
-                                  broker_str)
-                    raise
+                except Exception as e:
+                    log.error('Unable to connect to broker %s', broker_str)
+                    log.exception(e)
         # Couldn't connect anywhere. Raise an error.
-        raise Exception('Unable to connect to a broker to fetch metadata.')
+        raise RuntimeError(
+            'Unable to connect to a broker to fetch metadata. See logs.')
 
     def _update_brokers(self, broker_metadata):
         """Update brokers with fresh metadata.

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -167,6 +167,7 @@ class Cluster(object):
                 except:
                     log.exception('Unable to connect to broker %s',
                                   broker_str)
+                    raise
         # Couldn't connect anywhere. Raise an error.
         raise Exception('Unable to connect to a broker to fetch metadata.')
 


### PR DESCRIPTION
Without this change, an exception in the kafka connection results in just `Unable to connect to a broker to fetch metadata.` without any information about the error. An alternative to this would be to pass the exception object to the `log.exception` call, but re-raising the exception puts the user code in control.