### PR TITLE
leaderless topics

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -282,18 +282,14 @@ class Broker():
             future = self._req_handler.request(MetadataRequest(topics=topics))
             response = future.get(MetadataResponse)
 
-            errored = False
             for name, topic_metadata in response.topics.iteritems():
                 if topic_metadata.err == LeaderNotAvailable.ERROR_CODE:
-                    log.warning("Leader not available.")
-                    errored = True
+                    log.warning("Leader not available for topic '%s'.", name)
                 for pid, partition_metadata in topic_metadata.partitions.iteritems():
                     if partition_metadata.err == LeaderNotAvailable.ERROR_CODE:
-                        log.warning("Leader not available.")
-                        errored = True
-
-            if not errored:
-                return response
+                        log.warning("Leader not available for topic '%s' partition %d.",
+                                    name, pid)
+            return response
 
     ######################
     #  Commit/Fetch API  #

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -29,6 +29,7 @@ from .common import CompressionType
 from .exceptions import (
     InvalidMessageError,
     InvalidMessageSize,
+    LeaderNotAvailable,
     MessageSizeTooLarge,
     NotLeaderForPartition,
     ProduceFailureError,
@@ -284,6 +285,9 @@ class Producer(object):
                         log.warning('Produce request to %s:%s timed out. '
                                     'Retrying.', owned_broker.broker.host,
                                     owned_broker.broker.port)
+                    elif presponse.err == LeaderNotAvailable.ERROR_CODE:
+                        log.warning('Leader not available for partition %s.'
+                                    'Retrying.', partition)
                     elif presponse.err == InvalidMessageError.ERROR_CODE:
                         log.warning('Encountered InvalidMessageError')
                     elif presponse.err == InvalidMessageSize.ERROR_CODE:


### PR DESCRIPTION
don't return None when topic returns a Leader error - they will be caught in the producer/consumer'

Related to #225 