### PR TITLE
Fix _partition_messages in producer

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -198,7 +198,7 @@ class Producer():
             else:
                 key, value = message
             value = str(value)
-            yield (key, value), self._partitioner(partitions, message).id
+            yield (key, value), self._partitioner(partitions, key).id
 
     def _produce(self, message_partition_tups, attempt):
         """Publish a set of messages to relevant brokers.


### PR DESCRIPTION
_partition_messages(self, messages) was running the partitioner on the entire message instead of the key. Partitioners were not returning consistent partitions with the same key.