### PR TITLE
Ports are ints.

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -155,7 +155,7 @@ class Cluster(object):
             for broker_str in brokers:
                 try:
                     h, p = broker_str.split(':')
-                    broker = Broker(-1, h, p, self._handler,
+                    broker = Broker(-1, h, int(p), self._handler,
                                     self._socket_timeout_ms,
                                     self._offsets_channel_socket_timeout_ms,
                                     buffer_size=1024 * 1024,


### PR DESCRIPTION
On a client I was having issues with getaddrinfo() argument 2 must be an integer or string when using unicode string for the connection information (yay python 2...).

This seems to fix that case.