### PR TITLE
Make auto_offset_reset=-1 consume from latest with new consumer group

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -60,7 +60,7 @@ class BalancedConsumer():
                  fetch_wait_max_ms=100,
                  offsets_channel_backoff_ms=1000,
                  offsets_commit_max_retries=5,
-                 auto_offset_reset=OffsetType.LATEST,
+                 auto_offset_reset=OffsetType.EARLIEST,
                  consumer_timeout_ms=-1,
                  rebalance_max_retries=5,
                  rebalance_backoff_ms=2 * 1000,

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -153,7 +153,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
 
             # Since we are consuming from the latest offset,
             # produce more messages to consume.
-            for i in range(1000):
+            for i in range(2):
                 self.prod.produce('msg {num}'.format(num=i).encode())
 
             # Consume from both a few times

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -4,10 +4,9 @@ import time
 import unittest2
 
 from pykafka import KafkaClient
-from pykafka.balancedconsumer import BalancedConsumer
+from pykafka.balancedconsumer import BalancedConsumer, OffsetType
 from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import range
-
 
 def buildMockConsumer(num_partitions=10, num_participants=1, timeout=2000):
     consumer_group = 'testgroup'
@@ -99,24 +98,63 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         cls.topic_name = b'test-data'
         cls.kafka.create_topic(cls.topic_name, 3, 2)
         cls.client = KafkaClient(cls.kafka.brokers)
-        prod = cls.client.topics[cls.topic_name].get_producer(
+        cls.prod = cls.client.topics[cls.topic_name].get_producer(
             min_queued_messages=1
         )
         for i in range(1000):
-            prod.produce('msg {num}'.format(num=i).encode())
+            cls.prod.produce('msg {num}'.format(num=i).encode())
 
     @classmethod
     def tearDownClass(cls):
         stop_cluster(cls.kafka)
 
-    def test_consume(self):
+    def test_consume_earliest(self):
         try:
             consumer_a = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume', zookeeper_connect=self.kafka.zookeeper
+                b'test_consume_earliest', zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.EARLIEST
             )
             consumer_b = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume', zookeeper_connect=self.kafka.zookeeper
+                b'test_consume_earliest', zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.EARLIEST
             )
+
+            # Consume from both a few times
+            messages = [consumer_a.consume() for i in range(1)]
+            self.assertTrue(len(messages) == 1)
+            messages = [consumer_b.consume() for i in range(1)]
+            self.assertTrue(len(messages) == 1)
+
+            # Validate they aren't sharing partitions
+            self.assertSetEqual(
+                consumer_a._partitions & consumer_b._partitions,
+                set()
+            )
+
+            # Validate all partitions are here
+            self.assertSetEqual(
+                consumer_a._partitions | consumer_b._partitions,
+                set(self.client.topics[self.topic_name].partitions.values())
+            )
+        finally:
+            consumer_a.stop()
+            consumer_b.stop()
+
+    def test_consume_latest(self):
+        try:
+            consumer_a = self.client.topics[self.topic_name].get_balanced_consumer(
+                b'test_consume_latest', zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.LATEST
+            )
+            consumer_b = self.client.topics[self.topic_name].get_balanced_consumer(
+                b'test_consume_latest', zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.LATEST
+            )
+
+            # Since we are consuming from the latest offset,
+            # produce more messages to consume.
+            for i in range(1000):
+                self.prod.produce('msg {num}'.format(num=i).encode())
 
             # Consume from both a few times
             messages = [consumer_a.consume() for i in range(1)]


### PR DESCRIPTION
Fixes #241 so that auto_offset_reset=-1 consumes from latest available offset when the consumer group has no committed offsets.

This changes the default auto_offset_reset to -2 (earliest), so as not to break backwards
compatibility.  Hopefully this will be changed back to -1 in some future major version.