### PR TITLE
handle broker failure in producer

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -26,7 +26,8 @@ import weakref
 from .broker import Broker
 from .exceptions import (ConsumerCoordinatorNotAvailable,
                          KafkaException,
-                         UnknownTopicOrPartition)
+                         UnknownTopicOrPartition,
+                         LeaderNotAvailable)
 from .protocol import ConsumerMetadataRequest, ConsumerMetadataResponse
 from .topic import Topic
 from .utils.compat import iteritems, range
@@ -287,4 +288,8 @@ class Cluster(object):
                         'will NOT work. You need to create at least one topic '
                         'manually using the Kafka CLI tools.')
         self._update_brokers(metadata.brokers)
-        self._update_topics(metadata.topics)
+        try:
+            self._update_topics(metadata.topics)
+        except LeaderNotAvailable:
+            log.warning("LeaderNotAvailable encountered. This is "
+                        "because one or more partitions have no available replicas.")

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -277,19 +277,23 @@ class Cluster(object):
 
     def update(self):
         """Update known brokers and topics."""
-        metadata = self._get_metadata()
-        if len(metadata.brokers) == 0 and len(metadata.topics) == 0:
-            log.warning('No broker metadata found. If this is a fresh cluster, '
-                        'this may be due to a bug in Kafka. You can force '
-                        'broker metadata to be returned by manually creating '
-                        'a topic in the cluster. See '
-                        'https://issues.apache.org/jira/browse/KAFKA-2154 '
-                        'for information. Please note: topic auto-creation '
-                        'will NOT work. You need to create at least one topic '
-                        'manually using the Kafka CLI tools.')
-        self._update_brokers(metadata.brokers)
-        try:
-            self._update_topics(metadata.topics)
-        except LeaderNotAvailable:
-            log.warning("LeaderNotAvailable encountered. This is "
-                        "because one or more partitions have no available replicas.")
+        max_retries = 3
+        for i in xrange(max_retries):
+            metadata = self._get_metadata()
+            if len(metadata.brokers) == 0 and len(metadata.topics) == 0:
+                log.warning('No broker metadata found. If this is a fresh cluster, '
+                            'this may be due to a bug in Kafka. You can force '
+                            'broker metadata to be returned by manually creating '
+                            'a topic in the cluster. See '
+                            'https://issues.apache.org/jira/browse/KAFKA-2154 '
+                            'for information. Please note: topic auto-creation '
+                            'will NOT work. You need to create at least one topic '
+                            'manually using the Kafka CLI tools.')
+            self._update_brokers(metadata.brokers)
+            try:
+                self._update_topics(metadata.topics)
+            except LeaderNotAvailable:
+                log.warning("LeaderNotAvailable encountered. This is "
+                            "because one or more partitions have no available replicas.")
+            else:
+                break

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -75,11 +75,14 @@ class BrokerConnection(object):
 
     def connect(self, timeout):
         """Connect to the broker."""
+        log.debug("Connecting to %s:%s", self.host, self.port)
         self._socket = socket.create_connection(
             (self.host, self.port),
             timeout / 1000,
             (self.source_host, self.source_port)
         )
+        if self._socket is not None:
+            log.debug("Successfully connected to %s:%s", self.host, self.port)
 
     def disconnect(self):
         """Disconnect from the broker."""

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -131,7 +131,7 @@ class Partition():
             # Check leader
             if metadata.leader != self._leader.id:
                 log.info('Updating leader for %s from broker %s to broker %s', self,
-                          self._leader.id, metadata.leader)
+                         self._leader.id, metadata.leader)
                 self._leader = brokers[metadata.leader]
             # Check Replicas
             if sorted(r.id for r in self.replicas) != sorted(metadata.replicas):
@@ -142,6 +142,6 @@ class Partition():
                 log.info('Updating in sync replicas list for %s', self)
                 self._isr = [brokers[b] for b in metadata.isr]
         except KeyError:
-            raise LeaderNotAvailable("Leader for partition %s not available. This is "
+            raise LeaderNotAvailable("Replica for partition %s not available. This is "
                                      "probably because none of its replicas are "
                                      "available.", self.id)

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -20,6 +20,7 @@ __all__ = ["Partition"]
 import logging
 
 from .common import OffsetType
+from .exceptions import LeaderNotAvailable
 from .protocol import PartitionOffsetRequest
 
 log = logging.getLogger(__name__)
@@ -130,7 +131,7 @@ class Partition():
             # Check leader
             if metadata.leader != self._leader.id:
                 log.info('Updating leader for %s from broker %s to broker %s', self,
-                         self._leader.id, metadata.leader)
+                          self._leader.id, metadata.leader)
                 self._leader = brokers[metadata.leader]
             # Check Replicas
             if sorted(r.id for r in self.replicas) != sorted(metadata.replicas):
@@ -141,4 +142,6 @@ class Partition():
                 log.info('Updating in sync replicas list for %s', self)
                 self._isr = [brokers[b] for b in metadata.isr]
         except KeyError:
-            raise Exception("TODO: Type this exception")
+            raise LeaderNotAvailable("Leader for partition %s not available. This is "
+                                     "probably because none of its replicas are "
+                                     "available.", self.id)

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -129,7 +129,8 @@ class Partition():
         try:
             # Check leader
             if metadata.leader != self._leader.id:
-                log.info('Updating leader for %s', self)
+                log.info('Updating leader for %s from broker %s to broker %s', self,
+                         self._leader.id, metadata.leader)
                 self._leader = brokers[metadata.leader]
             # Check Replicas
             if sorted(r.id for r in self.replicas) != sorted(metadata.replicas):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -311,7 +311,11 @@ class Producer(object):
             log.warning('Broker %s:%s disconnected. Retrying.',
                         owned_broker.broker.host,
                         owned_broker.broker.port)
-            self._update()
+            try:
+                self._update()
+            except LeaderNotAvailable:
+                log.warning("LeaderNotAvailable encountered. This is "
+                            "because one or more partition has no available replicas.")
             to_retry = [
                 ((message.partition_key, message.value), p_id)
                 for topic, partitions in iteritems(req.msets)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -137,7 +137,7 @@ class Producer(object):
         self._owned_brokers = None
         self._running = False
         self._waiting_messages = []
-        self._waiting_messages_lock = self._cluster.handler.Lock()
+        self._waiting_messages_lock = self._cluster.handler.RLock()
         self._update_lock = self._cluster.handler.Lock()
         self.start()
 

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -311,11 +311,7 @@ class Producer(object):
             log.warning('Broker %s:%s disconnected. Retrying.',
                         owned_broker.broker.host,
                         owned_broker.broker.port)
-            try:
-                self._update()
-            except LeaderNotAvailable:
-                log.warning("LeaderNotAvailable encountered. This is "
-                            "because one or more partition has no available replicas.")
+            self._update()
             to_retry = [
                 ((message.partition_key, message.value), p_id)
                 for topic, partitions in iteritems(req.msets)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -190,6 +190,9 @@ class Producer(object):
     def stop(self):
         """Mark the producer as stopped"""
         self._running = False
+        if self._owned_brokers is not None:
+            for owned_broker in self._owned_brokers.values():
+                owned_broker.stop()
         self._wait_all()
 
     def produce(self, message, partition_key=None):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -504,15 +504,3 @@ class OwnedBroker(object):
             else:
                 raise ProducerQueueFullError("Queue full for broker %d",
                                              self.broker.id)
-
-    def resolve_event_state(self):
-        """Invariants for the Event variables used for thread synchronization
-        """
-        if len(self.queue) < self.producer._max_queued_messages:
-            self.slot_available.set()
-        else:
-            self.slot_available.clear()
-        if len(self.queue) >= self.producer._min_queued_messages:
-            self.flush_ready.set()
-        else:
-            self.flush_ready.clear()

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -189,7 +189,9 @@ class Producer(object):
     def _setup_owned_brokers(self):
         queued_messages = []
         if self._owned_brokers is not None:
-            for owned_broker in self._owned_brokers.values():
+            brokers = list(self._owned_brokers.keys())
+            for broker in brokers:
+                owned_broker = self._owned_brokers.pop(broker)
                 owned_broker.stop()
                 batch = owned_broker.flush(self._linger_ms)
                 if batch:

--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -152,7 +152,8 @@ class Message(Message, Serializable):
                  partition_key=None,
                  compression_type=CompressionType.NONE,
                  offset=-1,
-                 partition_id=-1):
+                 partition_id=-1,
+                 produce_attempt=0):
         self.compression_type = compression_type
         self.partition_key = partition_key
         self.value = value
@@ -162,6 +163,7 @@ class Message(Message, Serializable):
         self.partition_id = partition_id
         # self.partition is set by the consumer
         self.partition = None
+        self.produce_attempt = produce_attempt
 
     def __len__(self):
         size = 4 + 1 + 1 + 4 + 4 + len(self.value)


### PR DESCRIPTION
This pull request resolves #250 by making the producer resilient to certain broker failure modes. In particular, this pull request makes the producer able to handle the following cases.

Given a multi-node cluster with a topic with replication factor `N`:
* When `< N - 1` brokers become unavailable, the producer seamlessly updates its metadata and produces messages to the updated partition leaders.
* When `>= N - 1` brokers become unavailable, some partitions may not have enough available replicas, and thus will have no leader. In this case, the best a producer can do is to continue retrying messages destined for that partition until it becomes available. This pull request implements this behavior.
* When a broker in the connect string supplied to `Producer.__init__` is unavailable, the producer crashes with an error.

Non-producer changes (exception resilience):
* `Broker.request_metadata` continues its retry loop if it encounters `SocketDisconnected`, which can happen if a broker disconnects during the loop
* `Topic.update` and `Partition.update` raise `LeaderNotAvailable` when they encounter `KeyError`. This error happens when the metadata returned from the cluster indicates a broker that is not held in the `Cluster`'s registry, a common failure mode when brokers disconnect suddenly. `Cluster.update` catches `LeaderNotAvailable` and warns about it.

Producer changes:
* Add `running` to `OwnedBroker` to allow its thread to be stopped by its parent `Producer`. Stop worker threads when the `Producer` shuts down. This is not strictly related to handling broker failures.
* `NotLeaderForPartition` now causes the producer to `_update`, which refreshes cluster metadata and reinstantiates the `OwnedBroker`s.
* `SocketDisconnectedError` also causes the producer to `_update`.
* If the maximum number of retries is reached in `_send_request`, the messages are re-produced, placing them into the appropriate queues for their partition keys. This means that a partition with no available leader will continue to have its messages retried until the leader becomes available.