### PR TITLE
Get rid of zombie RequestHandler threads

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -133,6 +133,7 @@ class RequestHandler(object):
     def _start_thread(self):
         """Run the request processor"""
         self = weakref.proxy(self)
+
         def worker():
             try:
                 while not self.ending.is_set():
@@ -152,6 +153,6 @@ class RequestHandler(object):
                     finally:
                         self._requests.task_done()
             except ReferenceError:  # dead weakref
-                pass
+                log.warning("ReferenceError in handler - dead weakref")
             log.info("RequestHandler worker: exiting cleanly")
         return self.handler.spawn(worker)

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -20,10 +20,13 @@ __all__ = ["ResponseFuture", "Handler", "ThreadingHandler", "RequestHandler"]
 
 from collections import namedtuple
 import functools
+import logging
 import threading
 import weakref
 
 from .utils.compat import Queue, Empty
+
+log = logging.getLogger(__name__)
 
 
 class ResponseFuture(object):
@@ -123,6 +126,7 @@ class RequestHandler(object):
 
     def stop(self):
         """Stop the request processor."""
+        log.info("RequestHandler.stop: about to flush requests queue")
         self._requests.join()
         self.ending.set()
 
@@ -149,4 +153,5 @@ class RequestHandler(object):
                         self._requests.task_done()
             except ReferenceError:  # dead weakref
                 pass
+            log.info("RequestHandler worker: exiting cleanly")
         return self.handler.spawn(worker)


### PR DESCRIPTION
This fixes #257 by making sure `RequestHandler` instances are gc'able.

Because it removes the atexit flow completely, it also indirectly deals with #218 - with the changes here, `RequestHandler.stop` will run later in the teardown process, so that the consumers are already gone, so they no longer keep pressure on the request queue.
