### PR TITLE
travis: add back testinstances install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 
 
 install:
-    - pip install python-coveralls kazoo tox
+    - pip install python-coveralls kazoo tox testinstances
 
 before_script:
     - "python -m pykafka.test.kafka_instance 3 --download-dir /home/travis/kafka-bin &"


### PR DESCRIPTION
This was dropped in the test-suite upgrades as part of the py3
compatibility push.  As a result, the before-scripts fail, because there
is no testinstances installation outside the virtualenvs, and so every
TestCase has to instantiate a new test cluster.  Adding this back makes
things run a bit smoother.