### PR TITLE
latest_available_offset test

### DIFF
--- a/tests/pykafka/test_partition.py
+++ b/tests/pykafka/test_partition.py
@@ -29,7 +29,7 @@ class TestPartitionInfo(unittest2.TestCase):
     def test_can_get_latest_offset(self):
         partitions = self.client.topics[self.topic_name].partitions
         for partition in partitions.values():
-            self.assertTrue(partition.latest_available_offset())
+            self.assertTrue(partition.latest_available_offset() >= 0)
 
 if __name__ == "__main__":
     unittest2.main()


### PR DESCRIPTION
This pull request fixes `test_can_get_latest_offset` to not assume that all partitions have been committed to. This is acceptable because what it's really testing is whether the `PartitionOffsetRequest` completes without error, not whether the partition has had an offset committed.