### PR TITLE
Prevent infinite recursion when looking up internal topics

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -43,6 +43,9 @@ class TopicDict(dict):
         self._exclude_internal_topics = exclude_internal_topics
 
     def __getitem__(self, key):
+        if self._should_exclude_topic(key):
+            raise KeyError("You have configured KafkaClient/Cluster to hide "
+                           "double-underscored, internal topics")
         topic_ref = super(TopicDict, self).__getitem__(key)
         if topic_ref is not None and topic_ref() is not None:
             return topic_ref()

--- a/tests/pykafka/test_cluster.py
+++ b/tests/pykafka/test_cluster.py
@@ -20,6 +20,19 @@ class ClusterIntegrationTests(unittest.TestCase):
         topic = self.client.topics[topic_name]
         self.assertTrue(isinstance(topic, Topic))
 
+    def test_exclude_internal_topics(self):
+        """Test exclude_internal_topics setting
+
+        See also #277 for a related bug.
+        """
+        topic_name = b"__starts_with_underscores"
+        with self.assertRaises(KeyError):
+            topic = self.client.topics[topic_name]
+
+        client = KafkaClient(self.kafka.brokers, exclude_internal_topics=False)
+        topic = client.topics[topic_name]
+        self.assertTrue(isinstance(topic, Topic))
+
     def test_topic_updates(self):
         startlen = len(self.client.topics)
         name_a = uuid4().hex.encode()


### PR DESCRIPTION
Fixes #277. This is fairly low-impact: if you wanted to see internal topics, you'd usually set `exclude_internal_topics=False`.