### PR TITLE
SimpleConsumer/RdKafkaSimpleConsumer switching options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,10 @@ PyKafka
 .. image:: http://i.imgur.com/ztYl4lG.jpg
 
 PyKafka is a cluster-aware Kafka 0.8.2 protocol client for python. It includes python
-implementations of Kafka producers and consumers, and runs under python 2.7.
+implementations of Kafka producers and consumers, which are optionally backed
+by a C extension built on `librdkafka`_, and runs under python 2.7.
+
+.. _librdkafka: https://github.com/edenhill/librdkafka
 
 PyKafka's primary goal is to provide a similar level of abstraction to the
 `JVM Kafka client`_ using idioms familiar to python programmers and exposing
@@ -88,6 +91,21 @@ You can have as many `BalancedConsumer` instances consuming a topic as that
 topic has partitions. If they are all connected to the same zookeeper instance,
 they will communicate with it to automatically balance the partitions between
 themselves.
+
+Using the librdkafka extension
+------------------------------
+
+To use the librdkafka extension, you need to make sure the header files and
+shared library are somewhere where python can find them, both when you build
+the extension (which is taken care of by `setup.py develop`) and at run time.
+
+After that, all that's needed is that you pass an extra parameter
+`use_rdkafka=True` to `topic.get_simple_consumer()` (or
+`topic.get_balanced_consumer()`.
+
+We currently test against librdkafka `0.8.6`_ only.
+
+.. _0.8.6: https://github.com/edenhill/librdkafka/releases/tag/0.8.6
 
 What happened to Samsa?
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,14 @@ Using the librdkafka extension
 
 To use the librdkafka extension, you need to make sure the header files and
 shared library are somewhere where python can find them, both when you build
-the extension (which is taken care of by `setup.py develop`) and at run time.
+the extension (which is taken care of by ``setup.py develop``) and at run time.
+Typically, this means that you need to either install librdkafka in a place
+conventional for your system, or declare ``C_INCLUDE_PATH``, ``LIBRARY_PATH``,
+and ``LD_LIBRARY_PATH`` in your shell environment.
 
 After that, all that's needed is that you pass an extra parameter
-`use_rdkafka=True` to `topic.get_simple_consumer()` (or
-`topic.get_balanced_consumer()`.
+``use_rdkafka=True`` to ``topic.get_simple_consumer()`` (or
+``topic.get_balanced_consumer()``.
 
 We currently test against librdkafka `0.8.6`_ only.
 

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -73,7 +73,7 @@ class BalancedConsumer():
                  zookeeper=None,
                  auto_start=True,
                  reset_offset_on_start=False,
-                 use_rdkafka=True):
+                 use_rdkafka=False):
         """Create a BalancedConsumer instance
 
         :param topic: The topic this consumer should consume

--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -20,7 +20,6 @@ limitations under the License.
 __all__ = ["KafkaClient"]
 
 import logging
-import warnings
 
 from .cluster import Cluster
 from .handlers import ThreadingHandler
@@ -38,7 +37,6 @@ class KafkaClient(object):
                  use_greenlets=False,
                  socket_timeout_ms=30 * 1000,
                  offsets_channel_socket_timeout_ms=10 * 1000,
-                 ignore_rdkafka=None,
                  exclude_internal_topics=True,
                  source_address=''):
         """Create a connection to a Kafka cluster.
@@ -57,8 +55,6 @@ class KafkaClient(object):
             milliseconds) when reading responses for offset commit and
             offset fetch requests.
         :type offsets_channel_socket_timeout_ms: int
-        :param ignore_rdkafka: Deprecated, and in fact ignored. Instead, you
-            can set this on `Topic.get_simple_consumer` et al directly
         :param exclude_internal_topics: Whether messages from internal topics
             (specifically, the offsets topic) should be exposed to the consumer.
         :type exclude_internal_topics: bool
@@ -70,9 +66,6 @@ class KafkaClient(object):
         self._socket_timeout_ms = socket_timeout_ms
         self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._handler = None if use_greenlets else ThreadingHandler()
-        if ignore_rdkafka is not None:
-            warnings.warn("Unused setting: ignore_rdkafka", DeprecationWarning)
-
         self.cluster = Cluster(
             self._seed_hosts,
             self._handler,

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -155,7 +155,7 @@ class Topic():
 
     def get_simple_consumer(self,
                             consumer_group=None,
-                            use_rdkafka=True,
+                            use_rdkafka=False,
                             **kwargs):
         """Return a SimpleConsumer of this topic
 

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -28,6 +28,10 @@ from .producer import Producer
 from .protocol import PartitionOffsetRequest
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import iteritems, itervalues
+try:
+    from . import rdkafka
+except ImportError:
+    rdkafka = False
 
 
 log = logging.getLogger(__name__)
@@ -149,14 +153,23 @@ class Topic():
         except KeyError:
             raise LeaderNotAvailable()
 
-    def get_simple_consumer(self, consumer_group=None, **kwargs):
+    def get_simple_consumer(self,
+                            consumer_group=None,
+                            use_rdkafka=True,
+                            **kwargs):
         """Return a SimpleConsumer of this topic
 
         :param consumer_group: The name of the consumer group to join
         :type consumer_group: str
+        :param use_rdkafka: Use librdkafka-backed consumer if available
+        :type use_rdkafka: bool
         """
-        return SimpleConsumer(self, self._cluster,
-                              consumer_group=consumer_group, **kwargs)
+        Cls = (rdkafka.RdKafkaSimpleConsumer
+               if rdkafka and use_rdkafka else SimpleConsumer)
+        return Cls(self,
+                   self._cluster,
+                   consumer_group=consumer_group,
+                   **kwargs)
 
     def get_balanced_consumer(self, consumer_group, **kwargs):
         """Return a BalancedConsumer of this topic

--- a/tests/pykafka/rdkafka/test_simple_consumer.py
+++ b/tests/pykafka/rdkafka/test_simple_consumer.py
@@ -1,11 +1,12 @@
 from contextlib import contextmanager
 
-from tests.pykafka import test_simpleconsumer
+from tests.pykafka.test_balancedconsumer import BalancedConsumerIntegrationTests
+from tests.pykafka.test_simpleconsumer import TestSimpleConsumer
 from pykafka.rdkafka import RdKafkaSimpleConsumer
 from pykafka.utils.compat import range
 
 
-class TestRdKafkaSimpleConsumer(test_simpleconsumer.TestSimpleConsumer):
+class TestRdKafkaSimpleConsumer(TestSimpleConsumer):
 
     @contextmanager
     def _get_simple_consumer(self, **kwargs):
@@ -68,3 +69,7 @@ def _latest_partition_offsets_by_reading(consumer, n_reads):
         msg = consumer.consume()
         latest_offs[msg.partition_id] = msg.offset
     return latest_offs
+
+
+class RdkBalancedConsumerIntegrationTests(BalancedConsumerIntegrationTests):
+    USE_RDKAFKA = True

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -24,7 +24,7 @@ def buildMockConsumer(num_partitions=10, num_participants=1, timeout=2000):
     cluster = mock.MagicMock()
     zk = mock.MagicMock()
     return BalancedConsumer(topic, cluster, consumer_group,
-                            zookeeper=zk, auto_start=False,
+                            zookeeper=zk, auto_start=False, use_rdkafka=False,
                             consumer_timeout_ms=timeout), topic
 
 
@@ -91,6 +91,7 @@ class TestBalancedConsumer(unittest2.TestCase):
 
 class BalancedConsumerIntegrationTests(unittest2.TestCase):
     maxDiff = None
+    USE_RDKAFKA = False
 
     @classmethod
     def setUpClass(cls):
@@ -110,14 +111,17 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
 
     def test_consume_earliest(self):
         try:
-            consumer_a = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume_earliest', zookeeper_connect=self.kafka.zookeeper,
-                auto_offset_reset=OffsetType.EARLIEST
-            )
-            consumer_b = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume_earliest', zookeeper_connect=self.kafka.zookeeper,
-                auto_offset_reset=OffsetType.EARLIEST
-            )
+            topic = self.client.topics[self.topic_name]
+            consumer_a = topic.get_balanced_consumer(
+                b'test_consume_earliest',
+                zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.EARLIEST,
+                use_rdkafka=self.USE_RDKAFKA)
+            consumer_b = topic.get_balanced_consumer(
+                b'test_consume_earliest',
+                zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.EARLIEST,
+                use_rdkafka=self.USE_RDKAFKA)
 
             # Consume from both a few times
             messages = [consumer_a.consume() for i in range(1)]
@@ -142,14 +146,17 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
 
     def test_consume_latest(self):
         try:
-            consumer_a = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume_latest', zookeeper_connect=self.kafka.zookeeper,
-                auto_offset_reset=OffsetType.LATEST
-            )
-            consumer_b = self.client.topics[self.topic_name].get_balanced_consumer(
-                b'test_consume_latest', zookeeper_connect=self.kafka.zookeeper,
-                auto_offset_reset=OffsetType.LATEST
-            )
+            topic = self.client.topics[self.topic_name]
+            consumer_a = topic.get_balanced_consumer(
+                b'test_consume_latest',
+                zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.LATEST,
+                use_rdkafka=self.USE_RDKAFKA)
+            consumer_b = topic.get_balanced_consumer(
+                b'test_consume_latest',
+                zookeeper_connect=self.kafka.zookeeper,
+                auto_offset_reset=OffsetType.LATEST,
+                use_rdkafka=self.USE_RDKAFKA)
 
             # Since we are consuming from the latest offset,
             # produce more messages to consume.


### PR DESCRIPTION
This moves the rdkafka switch (which wasn't functioning yet, and which was written in a past where the rdkafka branch had its own implementations of `Cluster`, `Topic`, `Partition`, etc) out of `pykafka.client` and into `pykafka.topic`. You would then select an rdkafka-backed consumer like so: `topic.get_simple_consumer(use_rdkafka=True)` (and similarly for a balanced consumer).

Note this is a pullreq based on the rdkafka_extension branch, I split it out as it's probably useful to discuss separately.