### PR TITLE
consumer off-by-one

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -400,8 +400,10 @@ class SimpleConsumer():
                 else:
                     log.debug("Set offset for partition %s to %s",
                               owned_partition.partition.id,
-                              pres.offset)
-                    owned_partition.set_offset(pres.offset)
+                              pres.offset - 1)
+                    # offset fetch requests return the next offset to consume,
+                    # so account for this here by passing offset - 1
+                    owned_partition.set_offset(pres.offset - 1)
 
             # If any partitions didn't have a committed offset,
             # then reset those partition's offsets.
@@ -710,7 +712,7 @@ class OwnedPartition(object):
         return PartitionOffsetCommitRequest(
             self.partition.topic.name,
             self.partition.id,
-            self.last_offset_consumed,
+            self.last_offset_consumed + 1,
             int(time.time() * 1000),
             b'pykafka'
         )


### PR DESCRIPTION
This pull request changes the way `SimpleConsumer` maintains its internal offset counters. In `OffsetCommitRequest`s, the consumer now sends the *next* offset to consume rather than the last one consumed, fixing the issue raised in #289.

Based on the test cases in #289, this seems to be what Kafka expects. I can't find anywhere in the documentation whether this is technically correct or not, but I suppose hoping for that is a bit of a long shot given the state of their docs. This pull request also adjusts some existing consumer tests based on the assumption that Kafka expects this.