### PR TITLE
protocol: enable null payloads

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -224,13 +224,13 @@ class Producer(object):
     def produce(self, message, partition_key=None):
         """Produce a message.
 
-        :param message: The message to produce
+        :param message: The message to produce (use None to send null)
         :type message: bytes
         :param partition_key: The key to use when deciding which partition to send this
             message to
         :type partition_key: bytes
         """
-        if not isinstance(message, bytes):
+        if not (isinstance(message, bytes) or message is None):
             raise TypeError("Producer.produce accepts a bytes object, but it "
                             "got '%s'", type(message))
         if not self._running:

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -107,6 +107,15 @@ class ProducerIntegrationTests(unittest2.TestCase):
         prod = self.client.topics[self.topic_name].get_producer(**kwargs)
         prod.produce(uuid4().bytes)
 
+    def test_null_payloads(self):
+        """Test that None is accepted as a null payload"""
+        prod = self.client.topics[self.topic_name].get_sync_producer(
+                min_queued_messages=1)
+        prod.produce(None)
+        prod.produce(None, partition_key=b"whatever")
+        self.assertIsNone(self.consumer.consume().value)
+        self.assertIsNone(self.consumer.consume().value)
+
 
 if __name__ == "__main__":
     unittest2.main()

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -112,9 +112,11 @@ class ProducerIntegrationTests(unittest2.TestCase):
         prod = self.client.topics[self.topic_name].get_sync_producer(
                 min_queued_messages=1)
         prod.produce(None)
+        self.assertIsNone(self.consumer.consume().value)
         prod.produce(None, partition_key=b"whatever")
         self.assertIsNone(self.consumer.consume().value)
-        self.assertIsNone(self.consumer.consume().value)
+        prod.produce(b"")  # empty string should be distinguished from None
+        self.assertEqual(b"", self.consumer.consume().value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These changes enable both the producer and consumer to handle null payloads (represented as `None` in python), which are meaningful in kafka as "delete markers" for log compaction. I've added a test that sends and receives `None`.

Resolves #299.