### PR TITLE
[subject]: In handlers.py, add except SocketDisconnectedError; In con…

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -73,7 +73,7 @@ class BrokerConnection(object):
         """Returns true if the socket connection is open."""
         return self._socket is not None
 
-    def connect(self, timeout):
+    def connect(self, timeout=10 * 1000):
         """Connect to the broker."""
         log.debug("Connecting to %s:%s", self.host, self.port)
         self._socket = socket.create_connection(

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -24,6 +24,7 @@ import logging
 import threading
 import weakref
 
+from .exceptions import SocketDisconnectedError
 from .utils.compat import Queue, Empty
 
 log = logging.getLogger(__name__)
@@ -147,6 +148,11 @@ class RequestHandler(object):
                         if task.future:
                             res = self.connection.response()
                             task.future.set_response(res)
+                    except SocketDisconnectedError as e:
+                        # reconnect
+                        self.connection.reconnect()
+                        if task.future:
+                            task.future.set_error(e)
                     except Exception as e:
                         if task.future:
                             task.future.set_error(e)


### PR DESCRIPTION
When the socket is closed, The program will reconnect.
When the program executes `BrokerConnection.reconnect`, the program throws exception.

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/vagrant/github.com/.../pykafka/handlers.py", line 153, in worker
    self.connection.reconnect()
  File "/vagrant/github.com/.../pykafka/connection.py", line 101, in reconnect
    self.connect()
TypeError: connect() takes exactly 2 arguments (1 given)
```

The code of the raw program `BrokerConnection.reconnect`:
```
def reconnect(self):
        """Disconnect from the broker, then reconnect"""
        self.disconnect()
        self.connect()
```

I change the `BrokerConnection.connect`
```
 def connect(self, timeout):
        """Connect to the broker."""
        ...
```
to:
```
def connect(self, timeout=10 * 1000):
        """Connect to the broker."""
        ...
```