### PR TITLE
Recover after zk session loss

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -271,13 +271,15 @@ class BalancedConsumer():
         self._zookeeper = KazooClient(zookeeper_connect, timeout=timeout / 1000)
         self._zookeeper.start()
 
-    def _setup_internal_consumer(self, partitions=[], start=True):
+    def _setup_internal_consumer(self, partitions=None, start=True):
         """Instantiate an internal SimpleConsumer.
 
         If there is already a SimpleConsumer instance held by this object,
         disable its workers and mark it for garbage collection before
         creating a new one.
         """
+        if partitions is None:
+            partitions = []
         reset_offset_on_start = self._reset_offset_on_start
         if self._consumer is not None:
             self._consumer.stop()

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -505,7 +505,7 @@ class BalancedConsumer():
             owner_id, stat = self._zookeeper.get(
                 '{path}/{slug}'.format(
                     path=self._topic_path, slug=partition_slug))
-            if owner_id == self._consumer_id:
+            if owner_id == get_bytes(self._consumer_id):
                 zk_partition_ids.add(int(partition_slug.split('-')[1]))
         # build a set of partition ids we think we own
         internal_partition_ids = set([p.id for p in self._partitions])

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -525,7 +525,7 @@ class BalancedConsumer():
         if zk_partitions != self._partitions:
             log.warning("Internal partition registry doesn't match ZooKeeper!")
             log.debug("Internal partition ids: %s\nZooKeeper partition ids: %s",
-                      internal_partition_ids, zk_partition_ids)
+                      self._partitions, zk_partitions)
             return False
         return True
 

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -501,11 +501,14 @@ class BalancedConsumer():
         zk_partition_ids = set()
         all_partitions = self._zookeeper.get_children(self._topic_path)
         for partition_slug in all_partitions:
-            owner_id, stat = self._zookeeper.get(
-                '{path}/{slug}'.format(
-                    path=self._topic_path, slug=partition_slug))
-            if owner_id == get_bytes(self._consumer_id):
-                zk_partition_ids.add(int(partition_slug.split('-')[1]))
+            try:
+                owner_id, stat = self._zookeeper.get(
+                    '{path}/{slug}'.format(
+                        path=self._topic_path, slug=partition_slug))
+                if owner_id == get_bytes(self._consumer_id):
+                    zk_partition_ids.add(int(partition_slug.split('-')[1]))
+            except NoNodeException:
+                pass  # disappeared between ``get_children`` and ``get``
         return set(self._topic.partitions[_id] for _id in zk_partition_ids)
 
     def _check_held_partitions(self):

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -267,7 +267,7 @@ class BalancedConsumer():
         self._zookeeper = KazooClient(zookeeper_connect, timeout=timeout / 1000)
         self._zookeeper.start()
 
-    def _setup_internal_consumer(self, partitions, start=True):
+    def _setup_internal_consumer(self, partitions=[], start=True):
         """Instantiate an internal SimpleConsumer.
 
         If there is already a SimpleConsumer instance held by this object,

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -161,7 +161,7 @@ class SimpleConsumer():
 
         self._discover_offset_manager()
 
-        if partitions:
+        if partitions is not None:
             self._partitions = {p: OwnedPartition(p, self._messages_arrived)
                                 for p in partitions}
         else:

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -210,13 +210,14 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         zk.start()
         try:
             topic = self.client.topics[self.topic_name]
-            consumer = topic.get_balanced_consumer(b'test_zk_conn_lost',
-                                                   zookeeper=zk)
+            consumer_group = b'test_zk_conn_lost'
+
+            consumer = topic.get_balanced_consumer(consumer_group, zookeeper=zk)
             self.assertTrue(consumer._check_held_partitions())
             zk.stop()  # expires session, dropping all our nodes
 
             # Start a second consumer on a different zk connection
-            other_consumer = topic.get_balanced_consumer(b'test_zk_conn_lost')
+            other_consumer = topic.get_balanced_consumer(consumer_group)
 
             zk.start()
             time.sleep(.3)  # allow consumers time to begin rebalancing

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -39,7 +39,7 @@ class TestBalancedConsumer(unittest2.TestCase):
     def test_consume_returns(self):
         """Ensure that consume() returns in the amount of time it's supposed to
         """
-        self._mock_consumer._setup_internal_consumer([], start=False)
+        self._mock_consumer._setup_internal_consumer(start=False)
         start = time.time()
         self._mock_consumer.consume()
         self.assertEqual(int(time.time() - start), int(self._consumer_timeout / 1000))
@@ -49,7 +49,7 @@ class TestBalancedConsumer(unittest2.TestCase):
         end in an infinite loop when timeout is not used.
         """
         consumer, _ = buildMockConsumer(timeout=-1)
-        consumer._setup_internal_consumer([], start=False)
+        consumer._setup_internal_consumer(start=False)
 
         consumer.stop()
         self.assertIsNone(consumer.consume())

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -238,6 +238,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
             try:
                 consumer.stop()
                 other_consumer.stop()
+                zk.stop()
             except:
                 pass
 

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -39,7 +39,7 @@ class TestBalancedConsumer(unittest2.TestCase):
     def test_consume_returns(self):
         """Ensure that consume() returns in the amount of time it's supposed to
         """
-        self._mock_consumer._setup_internal_consumer(start=False)
+        self._mock_consumer._setup_internal_consumer([], start=False)
         start = time.time()
         self._mock_consumer.consume()
         self.assertEqual(int(time.time() - start), int(self._consumer_timeout / 1000))
@@ -49,7 +49,7 @@ class TestBalancedConsumer(unittest2.TestCase):
         end in an infinite loop when timeout is not used.
         """
         consumer, _ = buildMockConsumer(timeout=-1)
-        consumer._setup_internal_consumer(start=False)
+        consumer._setup_internal_consumer([], start=False)
 
         consumer.stop()
         self.assertIsNone(consumer.consume())


### PR DESCRIPTION
This changes `_rebalance()` to always use zk as the source of truth for what partitions we hold, rather than `self._partitions`. The main reason to do so is that `self._partitions` may be out of date, if `_rebalance()` is triggered after a zk session expiration. This was originally reported by @fortime in #215 - I'm however opting for a slightly more conservative solution (that is, querying zk every time).

This resolves #204. The new test in 8faf6c1 demonstrates the issue by simulating a session expiration. There are also two other fixes in 01368f6 and 23698e3 that were small enough that I thought I might as well slip them in here.
