### PR TITLE
Register atexit handlers for balancedconsumer and producer

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -35,6 +35,7 @@ from .exceptions import (KafkaException, PartitionOwnedError,
                          ConsumerStoppedException, ZookeeperConnectionLost)
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues
+from .utils.common import unregister_cleanup_func, register_cleanup_func
 
 
 log = logging.getLogger(__name__)
@@ -189,6 +190,13 @@ class BalancedConsumer():
         if auto_start is True:
             self.start()
 
+        def cleanup(obj):
+            obj.stop()
+        self._cleanup_func = cleanup
+
+        # Register a cleanup handler
+        register_cleanup_func(self._cleanup_func, self)
+
     def __repr__(self):
         return "<{module}.{name} at {id_} (consumer_group={group})>".format(
             module=self.__class__.__module__,
@@ -269,6 +277,11 @@ class BalancedConsumer():
             # additionally we'd want to remove watches here, but there are no
             # facilities for that in ChildrenWatch - as a workaround we check
             # self._running in the watcher callbacks (see further down)
+
+        # Unregister the cleanup handler
+        unregister_cleanup_func(self._cleanup_func, self)
+
+        del self._cleanup_func
 
     def _setup_zookeeper(self, zookeeper_connect, timeout):
         """Open a connection to a ZooKeeper host.

--- a/pykafka/utils/common.py
+++ b/pykafka/utils/common.py
@@ -1,0 +1,23 @@
+import atexit
+
+
+def unregister_cleanup_func(cleanup, obj):
+    """Unregister the cleanup handler"""
+    if hasattr(obj, '_cleanup_func'):
+        # Remove cleanup handler now that we've stopped
+        try:
+            # py3 supports unregistering
+            if hasattr(atexit, 'unregister'):
+                atexit.unregister(cleanup) # pylint: disable=no-member
+            # py2 requires removing from private attribute...
+            else:
+                # ValueError on list.remove() if the exithandler no longer exists
+                # but that is fine here
+                atexit._exithandlers.remove((cleanup, (obj,), {}))
+        except ValueError:
+            pass
+
+
+def register_cleanup_func(cleanup, obj):
+    """Register a cleanup handler"""
+    atexit.register(cleanup, obj)

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -2,12 +2,20 @@ from __future__ import division
 
 import time
 import unittest2
+import mock
 from uuid import uuid4
 
 from pykafka import KafkaClient
 from pykafka.exceptions import MessageSizeTooLarge, ProducerQueueFullError
 from pykafka.protocol import Message
 from pykafka.test.utils import get_cluster, stop_cluster
+
+
+class MockAtexit(mock.MagicMock):
+    _exithandlers = []
+
+    def unregister(self, func):
+        raise ValueError
 
 
 class ProducerIntegrationTests(unittest2.TestCase):
@@ -156,6 +164,30 @@ class ProducerIntegrationTests(unittest2.TestCase):
         prod.produce(b"")  # empty string should be distinguished from None
         self.assertEqual(b"", self.consumer.consume().value)
 
+    def test_cleanup_stop_is_not_called_on_stopped_object(self):
+        """Test that the stop() method is not called twice"""
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.stop()
+        self.assertFalse(hasattr(prod, '_cleanup_func'))
+
+    def test_cleanup_stop_is_called_on_not_stopped_object(self):
+        """Test that the cleanup() method flushes the queue properly"""
+        payload = uuid4().bytes
+
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.produce(payload)
+        # simulates a program termination
+        prod._cleanup_func(prod)
+        # confirm that message was received
+        message = self.consumer.consume()
+        self.assertEqual(message.value, payload)
+
+    @mock.patch('pykafka.utils.common.atexit', new=MockAtexit())
+    def test_failing_to_remove_cleanup_func(self):
+        """Test ValueError is ignored """
+        prod = self.client.topics[self.topic_name].get_producer()
+        prod.stop()
+        self.assertFalse(hasattr(prod, '_cleanup_func'))
 
 if __name__ == "__main__":
     unittest2.main()


### PR DESCRIPTION
This makes sure that the ``stop()`` method is called properly at ``program termination``. 