### PR TITLE
Empty partition assignment

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -431,6 +431,8 @@ class BalancedConsumer():
         """
         if self._consumer is not None:
             self.commit_offsets()
+        # this is necessary because we can't stop() while the lock is held
+        # (it's not an RLock)
         should_stop = False
         with self._rebalancing_lock:
             if not self._running:

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -30,7 +30,7 @@ from kazoo.recipe.watchers import ChildrenWatch
 
 from .common import OffsetType
 from .exceptions import (KafkaException, PartitionOwnedError,
-                         ConsumerStoppedException)
+                         ConsumerStoppedException, NoPartitionsForConsumerException)
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues
 
@@ -602,6 +602,8 @@ class BalancedConsumer():
                 return False
             disp = (time.time() - self._last_message_time) * 1000.0
             return disp > self._consumer_timeout_ms
+        if not self._partitions:
+            raise NoPartitionsForConsumerException()
         message = None
         self._last_message_time = time.time()
         while message is None and not consumer_timed_out():

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -198,9 +198,9 @@ class BalancedConsumer():
         """Start the zookeeper partition checker thread"""
         def checker():
             while True:
-                time.sleep(120)
                 if not self._running:
                     break
+                time.sleep(120)
                 if not self._check_held_partitions():
                     self._rebalance()
             log.debug("Checker thread exiting")
@@ -247,7 +247,8 @@ class BalancedConsumer():
             # rebalance that is already underway might re-register the zk
             # nodes that we remove here
             self._running = False
-        self._consumer.stop()
+        if self._consumer is not None:
+            self._consumer.stop()
         if self._owns_zookeeper:
             # NB this should always come last, so we do not hand over control
             # of our partitions until consumption has really been halted
@@ -430,6 +431,7 @@ class BalancedConsumer():
         """
         if self._consumer is not None:
             self.commit_offsets()
+        should_stop = False
         with self._rebalancing_lock:
             if not self._running:
                 raise ConsumerStoppedException
@@ -448,6 +450,11 @@ class BalancedConsumer():
                         participants.append(self._consumer_id)
 
                     new_partitions = self._decide_partitions(participants)
+                    if not new_partitions:
+                        should_stop = True
+                        log.warning("No partitions assigned to consumer %s - stopping",
+                                    self._consumer_id)
+                        break
 
                     # Update zk with any changes:
                     # Note that we explicitly fetch our set of held partitions
@@ -473,6 +480,8 @@ class BalancedConsumer():
                         raise
                     log.info('Unable to acquire partition %s. Retrying', ex.partition)
                     time.sleep(i * (self._rebalance_backoff_ms / 1000))
+        if should_stop:
+            self.stop()
 
     def _path_from_partition(self, p):
         """Given a partition, return its path in zookeeper.

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -40,6 +40,11 @@ class ConsumerStoppedException(KafkaException):
     pass
 
 
+class NoPartitionsForConsumerException(ConsumerStoppedException):
+    """Indicates that this consumer is stopped because it assigned itself zero partitions"""
+    pass
+
+
 class NoMessagesConsumedError(KafkaException):
     """Indicates that no messages were returned from a MessageSet"""
     pass

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -7,6 +7,7 @@ from kazoo.client import KazooClient
 
 from pykafka import KafkaClient
 from pykafka.balancedconsumer import BalancedConsumer, OffsetType
+from pykafka.exceptions import NoPartitionsForConsumerException
 from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import range
 
@@ -210,8 +211,9 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
                 auto_start=False)
         consumer._decide_partitions = lambda p: set()
         consumer.start()
-        time.sleep(1)
         self.assertFalse(consumer._running)
+        with self.assertRaises(NoPartitionsForConsumerException):
+            consumer.consume()
 
 
     def test_zk_conn_lost(self):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -201,6 +201,19 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         messages = [msg for msg in consumer]
         consumer.stop()
 
+
+    def test_no_partitions(self):
+        """Ensure a consumer assigned no partitions immediately exits"""
+        consumer = self.client.topics[self.topic_name].get_balanced_consumer(
+                b'test_no_partitions',
+                zookeeper_connect=self.kafka.zookeeper,
+                auto_start=False)
+        consumer._decide_partitions = lambda p: set()
+        consumer.start()
+        time.sleep(1)
+        self.assertFalse(consumer._running)
+
+
     def test_zk_conn_lost(self):
         """Check we restore zookeeper nodes correctly after connection loss
 


### PR DESCRIPTION
This pull request causes a `BalancedConsumer` that has no assigned partitions to immediately `stop()` itself. It fixes #313.