### PR TITLE
Suspend internal consumer during rebalancing and zk connection lapses

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -324,6 +324,8 @@ class BalancedConsumer():
         something more sophisticated here.
         """
         if self._consumer is not None:
+            log.debug(
+                "Suspending internal consumer ({})".format(self._consumer_id))
             self._consumer.stop()
 
     def _decide_partitions(self, participants):
@@ -557,9 +559,11 @@ class BalancedConsumer():
         return True
 
     def _get_zk_state_listener(self):
+        """Callback to suspend internal consumer when zk connection drops"""
         ref = weakref.ref(self)
 
         def listener(zk_state):
+            log.info("zk_state_listener: {}".format(zk_state))
             self = ref()
             if self is None:
                 return

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -32,7 +32,7 @@ from kazoo.recipe.watchers import ChildrenWatch
 
 from .common import OffsetType
 from .exceptions import (KafkaException, PartitionOwnedError,
-                         ConsumerStoppedException)
+                         ConsumerStoppedException, ZookeeperConnectionLost)
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues
 
@@ -565,7 +565,7 @@ class BalancedConsumer():
         def listener(zk_state):
             log.info("zk_state_listener: {}".format(zk_state))
             self = ref()
-            if self is None:
+            if self is None:  # should never happen as we use remove_listener()
                 return
             if zk_state != KazooState.CONNECTED:
                 # We don't handle the transition where the connection comes
@@ -638,6 +638,8 @@ class BalancedConsumer():
             except ConsumerStoppedException:
                 if not self._running:
                     return
+                elif not self._zookeeper.connected:
+                    raise ZookeeperConnectionLost
                 continue
             if message:
                 self._last_message_time = time.time()

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -32,8 +32,7 @@ from kazoo.recipe.watchers import ChildrenWatch
 
 from .common import OffsetType
 from .exceptions import (KafkaException, PartitionOwnedError,
-                         ConsumerStoppedException, ZookeeperConnectionLost,
-                         NoPartitionsForConsumerException)
+                         ConsumerStoppedException, ZookeeperConnectionLost)
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues
 
@@ -646,8 +645,8 @@ class BalancedConsumer():
                 return False
             disp = (time.time() - self._last_message_time) * 1000.0
             return disp > self._consumer_timeout_ms
-        if not self._partitions:
-            raise NoPartitionsForConsumerException()
+        if self._consumer is None:
+            raise ConsumerStoppedException
         message = None
         self._last_message_time = time.time()
         while message is None and not consumer_timed_out():

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -45,11 +45,6 @@ class ZookeeperConnectionLost(ConsumerStoppedException):
     pass
 
 
-class NoPartitionsForConsumerException(ConsumerStoppedException):
-    """Indicates that this consumer is stopped because it assigned itself zero partitions"""
-    pass
-
-
 class NoMessagesConsumedError(KafkaException):
     """Indicates that no messages were returned from a MessageSet"""
     pass

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -40,6 +40,11 @@ class ConsumerStoppedException(KafkaException):
     pass
 
 
+class ZookeeperConnectionLost(ConsumerStoppedException):
+    """Indicates consumer is waiting for its zk connection to recover"""
+    pass
+
+
 class NoMessagesConsumedError(KafkaException):
     """Indicates that no messages were returned from a MessageSet"""
     pass

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -7,8 +7,7 @@ from kazoo.client import KazooClient
 
 from pykafka import KafkaClient
 from pykafka.balancedconsumer import BalancedConsumer, OffsetType
-from pykafka.exceptions import (ZookeeperConnectionLost,
-                                NoPartitionsForConsumerException)
+from pykafka.exceptions import ZookeeperConnectionLost, ConsumerStoppedException
 from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import range
 
@@ -215,7 +214,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         consumer._decide_partitions = lambda p: set()
         consumer.start()
         self.assertFalse(consumer._running)
-        with self.assertRaises(NoPartitionsForConsumerException):
+        with self.assertRaises(ConsumerStoppedException):
             consumer.consume()
 
 


### PR DESCRIPTION
This resolves #273, borrowing a number of ideas initially proposed by @emmett9001 and @fortime in #206 and #215. On current master, the internal consumer will be left running until the very end of the rebalancing process, which could potentially stretch out over several retries (and which may fail, yet leaving the internal consumer live, auto-committing offsets on partitions it no longer owns).

With these changes, we suspend the internal consumer as soon as it becomes clear that it no longer holds the right set of partitions, and only then start further zookeeper back-and-forths to effect the rebalance.

The second change is that this adds a zk connection-status listener, so that if we "lose sight" of our zk nodes, we again suspend the internal consumer. (When the connection comes back, this will always trigger our watches, and thus a rebalance, so that didn't need implementing.)