### PR TITLE
connection: ensure reading the full Size field

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -109,11 +109,15 @@ class BrokerConnection(object):
 
     def response(self):
         """Wait for a response from the broker"""
-        size = self._socket.recv(4)
-        if len(size) == 0:
-            # Happens when broker has shut down
-            self.disconnect()
-            raise SocketDisconnectedError
+        size = b""  # Size => int32
+        while len(size) != 4:
+            r = self._socket.recv(4 - len(size))
+            if len(r) == 0:
+                # Happens when broker has shut down
+                self.disconnect()
+                raise SocketDisconnectedError
+            size += r
         size = struct.unpack('!i', size)[0]
         recvall_into(self._socket, self._buff, size)
+        # Drop CorrelationId => int32
         return buffer(self._buff[4:4 + size])

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -109,9 +109,10 @@ class BrokerConnection(object):
 
     def response(self):
         """Wait for a response from the broker"""
-        size = b""  # Size => int32
-        while len(size) != 4:
-            r = self._socket.recv(4 - len(size))
+        size = bytes()
+        expected_len = 4  # Size => int32
+        while len(size) != expected_len:
+            r = self._socket.recv(expected_len - len(size))
             if len(r) == 0:
                 # Happens when broker has shut down
                 self.disconnect()


### PR DESCRIPTION
BrokerConnection.response() did not check that it received all four
bytes of the Size field that precedes a ResponseMessage.  The result of
reading fewer bytes would be 1) an exception being raised when trying to
`struct.unpack()` it, and 2) the next caller of response() receiving
bogus data (because the previous call didn't `recv` the rest of its message).

This never tripped up any tests, as it would likely only ever fail on a
heavily loaded network.  It is a good candidate for explaining the kind
of problems reported in issues #318 and #312.

This commit only fixes our reading of the Size field.  Arguably, a more
complete fix would also make sure that the handler, when catching
exceptions from response(), would discard the connection, to prevent
the ensuing bogus data reads.