### PR TITLE
Handle broker failure in consumer

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -33,7 +33,8 @@ from .exceptions import (OffsetOutOfRangeError, UnknownTopicOrPartition,
                          OffsetMetadataTooLarge, OffsetsLoadInProgress,
                          NotCoordinatorForConsumer, SocketDisconnectedError,
                          ConsumerStoppedException, KafkaException,
-                         OffsetRequestFailedError, ERROR_CODES)
+                         NotLeaderForPartition, OffsetRequestFailedError,
+                         ERROR_CODES)
 from .protocol import (PartitionFetchRequest, PartitionOffsetCommitRequest,
                        PartitionOffsetFetchRequest, PartitionOffsetRequest)
 from .utils.error_handlers import (handle_partition_responses, raise_error,
@@ -243,9 +244,13 @@ class SimpleConsumer():
         def _handle_NotCoordinatorForConsumer(parts):
             self._discover_offset_manager()
 
+        def _handle_NotLeaderForPartition(parts):
+            self._update()
+
         return {
             UnknownTopicOrPartition.ERROR_CODE: lambda p: raise_error(UnknownTopicOrPartition),
             OffsetOutOfRangeError.ERROR_CODE: _handle_OffsetOutOfRangeError,
+            NotLeaderForPartition.ERROR_CODE: _handle_NotLeaderForPartition,
             OffsetMetadataTooLarge.ERROR_CODE: lambda p: raise_error(OffsetMetadataTooLarge),
             NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer
         }


### PR DESCRIPTION
This pull request fixes #223 by making the `SimpleConsumer` resilient to changes in broker availability.

The two cases it handles are 1) a currently connected broker losing its connection, and 2) an election causing the leaders of some partitions on the consumed topic to change. The first case is handled by updating the cluster metadata in response to a `SocketDisconnectedError` on `fetch()` instead of raising that exception. The second case is handled by updating the cluster metadata in response to a `NotLeaderForPartition` error on `fetch()`. Interestingly, the protocol documentation [words](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ErrorCodes) the description of `NotLeaderForPartition` in a way that implies that it can only be encountered in response to a `ProduceRequest`. Even so, the method in this pull request still appears to work.