### PR TITLE
SocketDisconnectedError in commit_offsets

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -304,6 +304,7 @@ class Cluster(object):
                 log.error("Socket disconnected during offset manager "
                           "discovery. This can happen when using PyKafka "
                           "with a Kafka version lower than 0.8.2.")
+                self.update()
             else:
                 coordinator = self.brokers.get(res.coordinator_id, None)
                 if coordinator is None:

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -259,10 +259,13 @@ class Cluster(object):
                 try:
                     self._brokers[id_].connect()
                 except socket.error:
-                    log.info('Failed to re-establish connection with broker id %s: %s:%s', id_, meta.host, meta.port)
+                    log.info('Failed to re-establish connection with broker id %s: %s:%s',
+                             id_, meta.host, meta.port)
             else:
                 broker = self._brokers[id_]
                 if meta.host == broker.host and meta.port == broker.port:
+                    log.info('Broker %s:%s metadata unchanged. Continuing.',
+                             broker.host, broker.port)
                     continue  # no changes
                 # TODO: Can brokers update? Seems like a problem if so.
                 #       Figure out and implement update/disconnect/reconnect if
@@ -298,9 +301,9 @@ class Cluster(object):
                 if i == MAX_RETRIES - 1:
                     raise
             except SocketDisconnectedError:
-                raise KafkaException("Socket disconnected during offset manager "
-                                     "discovery. This can happen when using PyKafka "
-                                     "with a Kafka version lower than 0.8.2.")
+                log.error("Socket disconnected during offset manager "
+                          "discovery. This can happen when using PyKafka "
+                          "with a Kafka version lower than 0.8.2.")
             else:
                 coordinator = self.brokers.get(res.coordinator_id, None)
                 if coordinator is None:

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -130,7 +130,7 @@ class Partition():
         """
         try:
             # Check leader
-            if metadata.leader != self._leader.id or not self._leader.connected:
+            if metadata.leader != self._leader.id:
                 log.info('Updating leader for %s from broker %s to broker %s', self,
                          self._leader.id, metadata.leader)
             self._leader = brokers[metadata.leader]

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -130,10 +130,10 @@ class Partition():
         """
         try:
             # Check leader
-            if metadata.leader != self._leader.id:
+            if metadata.leader != self._leader.id or not self._leader.connected:
                 log.info('Updating leader for %s from broker %s to broker %s', self,
                          self._leader.id, metadata.leader)
-                self._leader = brokers[metadata.leader]
+            self._leader = brokers[metadata.leader]
             # Check Replicas
             if sorted(r.id for r in self.replicas) != sorted(metadata.replicas):
                 log.info('Updating replicas list for %s', self)

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -245,6 +245,7 @@ class SimpleConsumer():
             self._discover_offset_manager()
 
         def _handle_NotLeaderForPartition(parts):
+            log.info("Updating cluster in response to NotLeaderForPartition")
             self._update()
 
         return {
@@ -393,8 +394,17 @@ class SimpleConsumer():
                 log.debug("Retrying")
             time.sleep(i * (self._offsets_channel_backoff_ms / 1000))
 
-            response = self._offset_manager.commit_consumer_group_offsets(
-                self._consumer_group, 1, b'pykafka', reqs)
+            try:
+                response = self._offset_manager.commit_consumer_group_offsets(
+                    self._consumer_group, 1, b'pykafka', reqs)
+            except (SocketDisconnectedError, IOError):
+                log.error("Error committing offsets for topic %s "
+                          "(SocketDisconnectedError)",
+                          self._topic.name)
+                if i >= self._offsets_commit_max_retries - 1:
+                    raise
+                continue
+
             parts_by_error = handle_partition_responses(
                 self._default_error_handlers,
                 response=response,
@@ -654,9 +664,10 @@ class SimpleConsumer():
                         timeout=self._fetch_wait_max_ms,
                         min_bytes=self._fetch_min_bytes
                     )
-                except (IOError, SocketDisconnectedError):
+                except (IOError, SocketDisconnectedError) as e:
                     if self._running:
                         unlock_partitions(iterkeys(partition_reqs))
+                        log.info("Updating cluster in response to error in fetch(): %s", e)
                         self._update()
                     # If the broker dies while we're supposed to stop,
                     # it's fine, and probably an integration test.

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -669,7 +669,8 @@ class SimpleConsumer():
                 except (IOError, SocketDisconnectedError):
                     unlock_partitions(iterkeys(partition_reqs))
                     if self._running:
-                        log.info("Updating cluster in response to error in fetch()")
+                        log.info("Updating cluster in response to error in fetch() "
+                                 "for broker id %s", broker.id)
                         self._update()
                     # If the broker dies while we're supposed to stop,
                     # it's fine, and probably an integration test.

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -664,10 +664,10 @@ class SimpleConsumer():
                         timeout=self._fetch_wait_max_ms,
                         min_bytes=self._fetch_min_bytes
                     )
-                except (IOError, SocketDisconnectedError) as e:
+                except (IOError, SocketDisconnectedError):
                     if self._running:
                         unlock_partitions(iterkeys(partition_reqs))
-                        log.info("Updating cluster in response to error in fetch(): %s", e)
+                        log.info("Updating cluster in response to error in fetch()")
                         self._update()
                     # If the broker dies while we're supposed to stop,
                     # it's fine, and probably an integration test.

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -206,6 +206,7 @@ class SimpleConsumer():
         with self._update_lock:
             self._cluster.update()
             self._setup_partitions_by_leader()
+            self._discover_offset_manager()
 
     def start(self):
         """Begin communicating with Kafka, including setting up worker threads
@@ -403,6 +404,7 @@ class SimpleConsumer():
                           self._topic.name)
                 if i >= self._offsets_commit_max_retries - 1:
                     raise
+                self._update()
                 continue
 
             parts_by_error = handle_partition_responses(
@@ -665,8 +667,8 @@ class SimpleConsumer():
                         min_bytes=self._fetch_min_bytes
                     )
                 except (IOError, SocketDisconnectedError):
+                    unlock_partitions(iterkeys(partition_reqs))
                     if self._running:
-                        unlock_partitions(iterkeys(partition_reqs))
                         log.info("Updating cluster in response to error in fetch()")
                         self._update()
                     # If the broker dies while we're supposed to stop,


### PR DESCRIPTION
This pull request stops the `SimpleConsumer`'s offset committer thread from dying when it encounters a `SocketDisconnectedError` as a result of a broker going down.

Resolves #325.