### PR TITLE
Stop ZK network disconnects from killing consumer

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -711,8 +711,6 @@ class BalancedConsumer():
             except ConsumerStoppedException:
                 if not self._running:
                     return
-                elif not self._zookeeper.connected:
-                    raise ZookeeperConnectionLost
                 continue
             if message:
                 self._last_message_time = time.time()

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -233,9 +233,6 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
             self.assertTrue(consumer._check_held_partitions())
 
             zk.stop()  # expires session, dropping all our nodes
-            time.sleep(.3)  # connection change signal needs time to propagate
-            with self.assertRaises(ZookeeperConnectionLost):
-                consumer.consume(block=False)
 
             # Start a second consumer on a different zk connection
             other_consumer = topic.get_balanced_consumer(consumer_group)


### PR DESCRIPTION
Addresses the issue raised in #346.

A Zookeeper connection loss shouldn't kill the main consumer thread, instead we should let Kazoo's session timeout happen if ZK is truly down for awhile.