### PR TITLE
broad LeaderNotAvailable

### DIFF
--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -134,20 +134,19 @@ class Topic():
         brokers = self._cluster.brokers
         if len(p_metas) > 0:
             log.info("Adding %d partitions", len(p_metas))
-        try:
-            for id_, meta in iteritems(p_metas):
-                if meta.id not in self._partitions:
-                    log.debug('Adding partition %s/%s', self.name, meta.id)
-                    self._partitions[meta.id] = Partition(
-                        self, meta.id,
-                        brokers[meta.leader],
-                        [brokers[b] for b in meta.replicas],
-                        [brokers[b] for b in meta.isr],
-                    )
-                else:
-                    self._partitions[id_].update(brokers, meta)
-        except KeyError:
-            raise LeaderNotAvailable()
+        for id_, meta in iteritems(p_metas):
+            if meta.leader not in brokers:
+                raise LeaderNotAvailable()
+            if meta.id not in self._partitions:
+                log.debug('Adding partition %s/%s', self.name, meta.id)
+                self._partitions[meta.id] = Partition(
+                    self, meta.id,
+                    brokers[meta.leader],
+                    [brokers[b] for b in meta.replicas],
+                    [brokers[b] for b in meta.isr],
+                )
+            else:
+                self._partitions[id_].update(brokers, meta)
 
     def get_simple_consumer(self, consumer_group=None, **kwargs):
         """Return a SimpleConsumer of this topic


### PR DESCRIPTION
This pull request tightens the conditions under which `topic.update()` will raise `LeaderNotAvailable` to the originally intended set of circumstances. The `try...except` that's currently in place was put there as a catch-all while making the cluster more resilient to broker failures, without too much thought for making the error more specific.