### PR TITLE
Topic instantiation improvements

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -26,7 +26,6 @@ import weakref
 from .broker import Broker
 from .exceptions import (ERROR_CODES,
                          ConsumerCoordinatorNotAvailable,
-                         KafkaException,
                          SocketDisconnectedError,
                          LeaderNotAvailable)
 from .protocol import ConsumerMetadataRequest, ConsumerMetadataResponse
@@ -56,10 +55,18 @@ class TopicDict(dict):
             return topic_ref()
         else:
             # Topic exists, but needs to be instantiated locally
-            meta = self._cluster()._get_metadata([key])
-            topic = Topic(self._cluster(), meta.topics[key])
-            self[key] = weakref.ref(topic)
-            return topic
+            max_retries = 3
+            for i in range(max_retries):
+                meta = self._cluster()._get_metadata([key])
+                try:
+                    topic = Topic(self._cluster(), meta.topics[key])
+                except LeaderNotAvailable:
+                    log.warning("LeaderNotAvailable encountered during Topic creation")
+                    if i == max_retries - 1:
+                        raise
+                else:
+                    self[key] = weakref.ref(topic)
+                    return topic
 
     def __missing__(self, key):
         log.warning('Topic %s not found. Attempting to auto-create.', key)
@@ -201,7 +208,7 @@ class Cluster(object):
     def _get_metadata(self, topics=None):
         """Get fresh cluster metadata from a broker."""
         # Works either on existing brokers or seed_hosts list
-        brokers = [b for b in self.brokers.values() if b.connected]
+        brokers = random.shuffle([b for b in self.brokers.values() if b.connected])
         if brokers:
             for broker in brokers:
                 response = broker.request_metadata(topics)
@@ -331,7 +338,7 @@ class Cluster(object):
             try:
                 self._topics._update_topics(metadata.topics)
             except LeaderNotAvailable:
-                log.warning("LeaderNotAvailable encountered. This is "
+                log.warning("LeaderNotAvailable encountered. This may be "
                             "because one or more partitions have no available replicas.")
             else:
                 break


### PR DESCRIPTION
This pull request makes `Topic.__init__` resilient to ephemeral `LeaderNotAvailable` errors caused by differences in Kafka's reporting on available brokers. It retries the creation of a new `Topic` three times, each time asking a randomly selected broker from the list of currently connected brokers.

Closes #338.