### PR TITLE
dead weakrefs

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -416,7 +416,7 @@ class BalancedConsumer(object):
         return participants
 
     def _build_watch_callback(self, fn, proxy):
-        """Return a function that's safe to use as a ChildrenWatch callbacks
+        """Return a function that's safe to use as a ChildrenWatch callback
 
         Fixes the issue from https://github.com/Parsely/pykafka/issues/345
         """

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -416,13 +416,16 @@ class BalancedConsumer(object):
         return participants
 
     def _build_watch_callback(self, fn, proxy):
-        """Return a function that's safe to use as a ChildrenWatch callback"""
+        """Return a function that's safe to use as a ChildrenWatch callbacks
+
+        Fixes the issue from https://github.com/Parsely/pykafka/issues/345
+        """
         def _callback(children):
             # discover whether the referenced object still exists
             try:
                 proxy.__repr__()
             except ReferenceError:
-                return
+                return False
             return fn(proxy, children)
         return _callback
 


### PR DESCRIPTION
This pull request improves the `ChildrenWatch` callbacks registered by `BalancedConsumer`, making them safe to use even after the `BalancedConsumer` that created them is no longer referenced by the `weakref.proxy` used in their creation. It uses `__repr__` as a cheap way to discover whether the object is still referenced, and simply passes if not. This is a way around the fact that `KazooClient` lacks a way to explicitly remove `ChildrenWatch` objects from zookeeper.

Fixes #345.