### PR TITLE
held_offsets idempotency

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -283,7 +283,9 @@ class SimpleConsumer(object):
     @property
     def held_offsets(self):
         """Return a map from partition id to held offset for each partition"""
-        return {p.partition.id: p.last_offset_consumed
+        return {p.partition.id:
+                (OffsetType.EARLIEST if p.last_offset_consumed == -1
+                 else p.last_offset_consumed)
                 for p in itervalues(self._partitions_by_id)}
 
     def __del__(self):


### PR DESCRIPTION
This pull request makes `held_offsets()` return `-2` (`OffsetType.EARLIEST`) when the consumer holds `-1`. This fixes #216 by allowing the output from `held_offsets()` to be used directly as input to `reset_offsets` without producing unexpected results.