### PR TITLE
zk connect strings in Cluster()

### DIFF
--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -47,7 +47,8 @@ class KafkaClient(object):
         Documentation for source_address can be found at
         https://docs.python.org/2/library/socket.html#socket.create_connection
 
-        :param hosts: Comma-separated list of kafka hosts to used to connect.
+        :param hosts: Comma-separated list of kafka hosts to used to connect. Also
+            accepts a KazooClient connect string.
         :type hosts: bytes
         :param socket_timeout_ms: The socket timeout (in milliseconds) for
             network requests

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -175,6 +175,7 @@ class Cluster(object):
         self._source_address = source_address
         self._source_host = self._source_address.split(':')[0]
         self._source_port = 0
+        self._zookeeper_connect = None
         if ':' in self._source_address:
             self._source_port = int(self._source_address.split(':')[1])
         self.update()
@@ -267,6 +268,7 @@ class Cluster(object):
 
                 metadata = self._request_metadata(broker_connects, topics)
                 if metadata is not None:
+                    self._zookeeper_connect = self._seed_hosts
                     return metadata
 
         # Couldn't connect anywhere. Raise an error.

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -18,10 +18,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 __all__ = ["Cluster"]
+import json
 import logging
 import random
 import time
 import weakref
+
+from kazoo.client import KazooClient
 
 from .broker import Broker
 from .exceptions import (ERROR_CODES,
@@ -145,7 +148,8 @@ class Cluster(object):
                  source_address=''):
         """Create a new Cluster instance.
 
-        :param hosts: Comma-separated list of kafka hosts to used to connect.
+        :param hosts: Comma-separated list of kafka hosts to used to connect. Also
+            accepts a KazooClient connect string
         :type hosts: bytes
         :param handler: The concurrency handler for network requests.
         :type handler: :class:`pykafka.handlers.Handler`
@@ -198,6 +202,30 @@ class Cluster(object):
         """The concurrency handler for network requests"""
         return self._handler
 
+    def _request_metadata(self, broker_connects, topics):
+        """Request broker metadata from a set of brokers
+
+        Returns the result of the first successful metadata request
+
+        :param broker_connects: The set of brokers to which to attempt to connect
+        :type broker_connects: Iterable of two-element sequences of the format
+            (broker_host, broker_port)
+        """
+        try:
+            for host, port in broker_connects:
+                broker = Broker(-1, host, int(port), self._handler,
+                                self._socket_timeout_ms,
+                                self._offsets_channel_socket_timeout_ms,
+                                buffer_size=1024 * 1024,
+                                source_host=self._source_host,
+                                source_port=self._source_port)
+                response = broker.request_metadata(topics)
+                if response is not None:
+                    return response
+        except Exception as e:
+            log.error('Unable to connect to broker %s:%s', host, port)
+            log.exception(e)
+
     def _get_metadata(self, topics=None):
         """Get fresh cluster metadata from a broker."""
         # Works either on existing brokers or seed_hosts list
@@ -208,22 +236,39 @@ class Cluster(object):
                 if response is not None:
                     return response
         else:  # try seed hosts
-            brokers = self._seed_hosts.split(',')
-            for broker_str in brokers:
+            metadata = None
+            broker_connects = [broker_str.split(":")
+                               for broker_str in self._seed_hosts.split(',')]
+            metadata = self._request_metadata(broker_connects, topics)
+            if metadata is not None:
+                return metadata
+
+            # try treating seed_hosts as a zookeeper host list
+            zookeeper = KazooClient(self._seed_hosts, timeout=self._socket_timeout_ms)
+            try:
+                zookeeper.start()
+            except Exception as e:
+                log.error('Unable to connect to ZooKeeper instance %s', self._seed_hosts)
+                log.exception(e)
+            else:
                 try:
-                    h, p = broker_str.split(':')
-                    broker = Broker(-1, h, int(p), self._handler,
-                                    self._socket_timeout_ms,
-                                    self._offsets_channel_socket_timeout_ms,
-                                    buffer_size=1024 * 1024,
-                                    source_host=self._source_host,
-                                    source_port=self._source_port)
-                    response = broker.request_metadata(topics)
-                    if response is not None:
-                        return response
+                    # get a list of connect strings from zookeeper
+                    brokers_path = "/brokers/ids/"
+                    broker_ids = zookeeper.get_children(brokers_path)
+                    broker_connects = []
+                    for broker_id in broker_ids:
+                        broker_json, _ = zookeeper.get("{}{}".format(brokers_path, broker_id))
+                        broker_info = json.loads(broker_json.decode("utf-8"))
+                        broker_connects.append((broker_info['host'], broker_info['port']))
+                    zookeeper.stop()
                 except Exception as e:
-                    log.error('Unable to connect to broker %s', broker_str)
+                    log.error('Unable to fetch broker info from ZooKeeper')
                     log.exception(e)
+
+                metadata = self._request_metadata(broker_connects, topics)
+                if metadata is not None:
+                    return metadata
+
         # Couldn't connect anywhere. Raise an error.
         raise RuntimeError(
             'Unable to connect to a broker to fetch metadata. See logs.')

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -163,4 +163,7 @@ class Topic(object):
         :param consumer_group: The name of the consumer group to join
         :type consumer_group: str
         """
+        if "zookeeper_connect" not in kwargs and \
+                self._cluster._zookeeper_connect is not None:
+            kwargs['zookeeper_connect'] = self._cluster._zookeeper_connect
         return BalancedConsumer(self, self._cluster, consumer_group, **kwargs)

--- a/tests/pykafka/test_cluster.py
+++ b/tests/pykafka/test_cluster.py
@@ -2,6 +2,7 @@ import unittest
 from uuid import uuid4
 
 from pykafka import KafkaClient, Topic
+from pykafka.utils.compat import itervalues
 from pykafka.test.utils import get_cluster, stop_cluster
 
 
@@ -55,6 +56,15 @@ class ClusterIntegrationTests(unittest.TestCase):
         self.assertEqual(len(self.client.topics), startlen)
         self.assertNotIn(name_b, self.client.topics)
 
+    def test_zk_connect(self):
+        """Clusters started with broker lists and zk connect strings should get same brokers"""
+        zk_client = KafkaClient(self.kafka.zookeeper)
+        kafka_client = KafkaClient(self.kafka.brokers)
+        zk_brokers = ["{}:{}".format(b.host, b.port)
+                      for b in itervalues(zk_client.brokers)]
+        kafka_brokers = ["{}:{}".format(b.host, b.port)
+                         for b in itervalues(kafka_client.brokers)]
+        self.assertEqual(zk_brokers, kafka_brokers)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request implements #316 by falling back to `KazooClient` in `Cluster._get_metadata`. `KafkaClient` still accepts a list of brokers, but in cases where it can't connect to any of those brokers, it attempts to connect a `KazooClient` to the list of hosts and to get the list of brokers from that ZooKeeper instance.