### PR TITLE
Updated test for rebalance callback, various fixes

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -591,9 +591,8 @@ class BalancedConsumer(object):
                                 self, old_offsets, new_offsets)
                             if reset_offsets:
                                 cns.reset_offsets(partition_offsets=[
-                                    (part, reset_offsets[part.id])
-                                    for part in itervalues(cns.partitions)
-                                    if part.id in reset_offsets])
+                                    (cns.partitions[id_], offset) for
+                                    (id_, offset) in iteritems(reset_offsets)])
                         self._consumer = cns
 
                     log.info('Rebalancing Complete.')

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -593,7 +593,7 @@ class BalancedConsumer(object):
                                 cns.reset_offsets(partition_offsets=[
                                     (part, reset_offsets[part.id])
                                     for part in itervalues(cns.partitions)
-                                    if part.id in new_offsets])
+                                    if part.id in reset_offsets])
                         self._consumer = cns
 
                     log.info('Rebalancing Complete.')

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -528,19 +528,6 @@ class BalancedConsumer(object):
 
         This method is called whenever a zookeeper watch is triggered.
         """
-        def _get_held_offsets(partitions, cns):
-            """Return held offsets from a consumer for a set of partitions
-
-            :param partitions: The partitions for which to return currently held offsets
-            :type partitions: Iterable of :class:`pykafka.partition.Partition`
-            :param cns: The consumer from which to fetch held offsets
-            :type cns: :class:`pykafka.simpleconsumer.SimpleConsumer`
-            """
-            if cns is None:
-                return {}
-            ids = [partition.id for partition in partitions]
-            return {id_: offset for id_, offset in iteritems(cns.held_offsets) if id_ in ids}
-
         if self._consumer is not None:
             self.commit_offsets()
         # this is necessary because we can't stop() while the lock is held
@@ -584,9 +571,10 @@ class BalancedConsumer(object):
                     # Only re-create internal consumer if something changed.
                     if new_partitions != self._partitions:
                         cns = self._get_internal_consumer(list(new_partitions))
-                        old_offsets = _get_held_offsets(current_zk_parts, self._consumer)
-                        new_offsets = _get_held_offsets(new_partitions, cns)
                         if self._post_rebalance_callback is not None:
+                            old_offsets = (self._consumer.held_offsets
+                                           if self._consumer else dict())
+                            new_offsets = cns.held_offsets
                             reset_offsets = self._post_rebalance_callback(
                                 self, old_offsets, new_offsets)
                             if reset_offsets:

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -163,8 +163,8 @@ class BalancedConsumer(object):
             internal offset counter to `self._auto_offset_reset` and commit that
             offset immediately upon starting up
         :type reset_offset_on_start: bool
-        :param post_rebalance_callback: A function to be called when a rebalance has
-            completed. This function should accept three arguments: the
+        :param post_rebalance_callback: A function to be called when a rebalance is
+            in progress. This function should accept three arguments: the
             :class:`pykafka.balancedconsumer.BalancedConsumer` instance that just
             completed its rebalance, a dict of partitions that it owned before the
             rebalance, and a dict of partitions it owns after the rebalance. These dicts
@@ -172,6 +172,11 @@ class BalancedConsumer(object):
             This function can optionally return a dictionary mapping partition ids to
             offsets. If it does, the consumer will reset its offsets to the supplied
             values before continuing consumption.
+            Note that the BalancedConsumer is in a poorly defined state at
+            the time this callback runs, so that accessing its properties
+            (such as `held_offsets` or `partitions`) might yield confusing
+            results.  Instead, the callback should really rely on the
+            provided partition-id dicts, which are well-defined.
         :type post_rebalance_callback: function
         :param use_rdkafka: Use librdkafka-backed consumer if available
         :type use_rdkafka: bool

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -276,7 +276,7 @@ class BalancedConsumer(object):
 
     @property
     def partitions(self):
-        return self._consumer.partitions if self._consumer else None
+        return self._consumer.partitions if self._consumer else dict()
 
     @property
     def _partitions(self):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -121,14 +121,6 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
     def test_rebalance_callbacks(self):
         def on_rebalance(cns, old_partition_offsets, new_partition_offsets):
             self.assertTrue(len(new_partition_offsets) > 0)
-            held_ids = set([p.id for p in cns._get_held_partitions()])
-            new_ids = set(iterkeys(new_partition_offsets))
-            old_ids = set(iterkeys(old_partition_offsets))
-            revoked_ids = old_ids - new_ids
-            assigned_ids = new_ids - old_ids
-            self.assertEqual(assigned_ids & revoked_ids, set())
-            self.assertEqual(held_ids | new_ids, held_ids)
-            self.assertNotEqual(held_ids & old_ids, held_ids)
             self.assigned_called = True
             for id_ in iterkeys(new_partition_offsets):
                 new_partition_offsets[id_] = self.offset_reset
@@ -330,6 +322,8 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
                 break
             else:
                 time.sleep(.2)
+            # check for failed consumers (there'd be no point waiting anymore)
+            [cons._raise_worker_exceptions() for cons in balanced_consumers]
         else:
             raise AssertionError("Rebalancing failed")
 


### PR DESCRIPTION
The main thing here is that I wanted the test to work with the `wait_for_rebalancing()` helper and it didn't pass. This is fixed in 64ab07f which relaxes the test assertions (and makes the case for that). A few other bits slipped in during further testing.

One question perhaps: do we think d8f79cd is a backward-incompatible fix?