### PR TITLE
error_handlers: don't hide KeyErrors

### DIFF
--- a/pykafka/utils/error_handlers.py
+++ b/pykafka/utils/error_handlers.py
@@ -42,16 +42,14 @@ def handle_partition_responses(error_handlers,
     :type partitions_by_id: dict
         {int: :class:`pykafka.simpleconsumer.OwnedPartition`}
     """
-    error_handlers = error_handlers.copy()
-    if success_handler is not None:
-        error_handlers[0] = success_handler
-
     if parts_by_error is None:
         parts_by_error = build_parts_by_error(response, partitions_by_id)
 
     for errcode, parts in iteritems(parts_by_error):
-        if errcode in error_handlers:
+        if errcode != 0:
             error_handlers[errcode](parts)
+        elif success_handler is not None:
+            success_handler(parts)
 
     return parts_by_error
 


### PR DESCRIPTION
Previously, this utility would silently drop any errors for which we
haven't defined a handler.  The changes here drop the `if errcode in
error_handlers`, so that a KeyError will be raised if we encounter
unexpected errors.  This should help in our Kafka-0.9 compatibility
push, by not concealing any newly defined Kafka 0.9 error codes.