### PR TITLE
enforce bytes consumer group argument

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -182,6 +182,8 @@ class BalancedConsumer(object):
         :type use_rdkafka: bool
         """
         self._cluster = cluster
+        if not isinstance(consumer_group, bytes):
+            raise TypeError("consumer_group must be a bytes object")
         self._consumer_group = consumer_group
         self._topic = topic
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -133,7 +133,7 @@ class SimpleConsumer(object):
         :type reset_offset_on_start: bool
         """
         self._cluster = cluster
-        if not isinstance(consumer_group, bytes):
+        if not (isinstance(consumer_group, bytes) or consumer_group is None):
             raise TypeError("consumer_group must be a bytes object")
         self._consumer_group = consumer_group
         self._topic = topic

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -133,6 +133,8 @@ class SimpleConsumer(object):
         :type reset_offset_on_start: bool
         """
         self._cluster = cluster
+        if not isinstance(consumer_group, bytes):
+            raise TypeError("consumer_group must be a bytes object")
         self._consumer_group = consumer_group
         self._topic = topic
         self._fetch_message_max_bytes = fetch_message_max_bytes
@@ -324,8 +326,8 @@ class SimpleConsumer(object):
     def _setup_fetch_workers(self):
         """Start the fetcher threads"""
         # NB this gets overridden in rdkafka.RdKafkaSimpleConsumer
-
         self = weakref.proxy(self)
+
         def fetcher():
             while True:
                 try:

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -13,7 +13,7 @@ from pykafka.utils.compat import range, iterkeys, iteritems
 
 
 def buildMockConsumer(num_partitions=10, num_participants=1, timeout=2000):
-    consumer_group = 'testgroup'
+    consumer_group = b'testgroup'
     topic = mock.Mock()
     topic.name = 'testtopic'
     topic.partitions = {}


### PR DESCRIPTION
Fixes #376 by improving the error message given when unicode is supplied to a consumer constructor.