### PR TITLE
rdkafka: fix reference leak in Consumer_consume()

### DIFF
--- a/pykafka/rdkafka/_rd_kafkamodule.c
+++ b/pykafka/rdkafka/_rd_kafkamodule.c
@@ -965,7 +965,7 @@ Consumer_consume(RdkHandle *self, PyObject *args)
 #else
         const char *format = "{s:s#,s:s#,s:l,s:L}";
 #endif
-        PyObject *kwargs = Py_BuildValue(
+        kwargs = Py_BuildValue(
             format,
             "value", rkmessage->payload, rkmessage->len,
             "partition_key", rkmessage->key, rkmessage->key_len,


### PR DESCRIPTION
This was introduced with 5d7abfa2 - there's a Py_XDECREF in place, but
the erroneously declared block-scoped variable is not the one that gets
DECREF'd.  Resolves #379.