### PR TITLE
early unicode warnings

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -50,6 +50,9 @@ class TopicDict(dict):
         return [self[key] for key in self]
 
     def __getitem__(self, key):
+        if not isinstance(key, bytes):
+            raise TypeError("TopicDict.__getitem__ accepts a bytes object, but it "
+                            "got '%s'", type(key))
         if self._should_exclude_topic(key):
             raise KeyError("You have configured KafkaClient/Cluster to hide "
                            "double-underscored, internal topics")

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -245,8 +245,11 @@ class Producer(object):
             message to
         :type partition_key: bytes
         """
+        if not (isinstance(partition_key, bytes) or partition_key is None):
+            raise TypeError("Producer.produce accepts a bytes object as partition_key, "
+                            "but it got '%s'", type(partition_key))
         if not (isinstance(message, bytes) or message is None):
-            raise TypeError("Producer.produce accepts a bytes object, but it "
+            raise TypeError("Producer.produce accepts a bytes object as message, but it "
                             "got '%s'", type(message))
         if not self._running:
             raise ProducerStoppedException()


### PR DESCRIPTION
This pull request makes unicode-related errors clearer to the end user in `TopicDict` and `produce()`. It fixes #386.