### PR TITLE
NoPartitionsForConsumer fix

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -511,7 +511,6 @@ class BalancedConsumer(object):
             self.commit_offsets()
         # this is necessary because we can't stop() while the lock is held
         # (it's not an RLock)
-        should_stop = False
         with self._rebalancing_lock:
             if not self._running:
                 raise ConsumerStoppedException
@@ -531,7 +530,6 @@ class BalancedConsumer(object):
 
                     new_partitions = self._decide_partitions(participants)
                     if not new_partitions:
-                        should_stop = True
                         log.warning("No partitions assigned to consumer %s - stopping",
                                     self._consumer_id)
                         break
@@ -571,8 +569,6 @@ class BalancedConsumer(object):
                         raise
                     log.info('Unable to acquire partition %s. Retrying', ex.partition)
                     time.sleep(i * (self._rebalance_backoff_ms / 1000))
-        if should_stop:
-            self.stop()
 
     def _path_from_partition(self, p):
         """Given a partition, return its path in zookeeper.

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -32,8 +32,7 @@ from kazoo.exceptions import NoNodeException, NodeExistsError
 from kazoo.recipe.watchers import ChildrenWatch
 
 from .common import OffsetType
-from .exceptions import (KafkaException, PartitionOwnedError,
-                         ConsumerStoppedException, NoPartitionsForConsumerException)
+from .exceptions import KafkaException, PartitionOwnedError, ConsumerStoppedException
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues, iteritems
 try:
@@ -683,9 +682,9 @@ class BalancedConsumer(object):
                 return False
             disp = (time.time() - self._last_message_time) * 1000.0
             return disp > self._consumer_timeout_ms
-        if not self._partitions:
-            raise NoPartitionsForConsumerException()
         message = None
+        if self._consumer is None:
+            return
         self._last_message_time = time.time()
         while message is None and not consumer_timed_out():
             self._raise_worker_exceptions()

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -530,9 +530,8 @@ class BalancedConsumer(object):
 
                     new_partitions = self._decide_partitions(participants)
                     if not new_partitions:
-                        log.warning("No partitions assigned to consumer %s - stopping",
+                        log.warning("No partitions assigned to consumer %s",
                                     self._consumer_id)
-                        break
 
                     # Update zk with any changes:
                     # Note that we explicitly fetch our set of held partitions

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -678,16 +678,14 @@ class BalancedConsumer(object):
             disp = (time.time() - self._last_message_time) * 1000.0
             return disp > self._consumer_timeout_ms
         message = None
-        if self._consumer is None:
-            return
         self._last_message_time = time.time()
         while message is None and not consumer_timed_out():
             self._raise_worker_exceptions()
             try:
                 message = self._consumer.consume(block=block)
-            except ConsumerStoppedException:
+            except (ConsumerStoppedException, AttributeError):
                 if not self._running:
-                    raise
+                    raise ConsumerStoppedException
                 continue
             if message:
                 self._last_message_time = time.time()

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -40,11 +40,6 @@ class ConsumerStoppedException(KafkaException):
     pass
 
 
-class NoPartitionsForConsumerException(ConsumerStoppedException):
-    """Indicates that this consumer is stopped because it assigned itself zero partitions"""
-    pass
-
-
 class NoMessagesConsumedError(KafkaException):
     """Indicates that no messages were returned from a MessageSet"""
     pass

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -8,7 +8,7 @@ from kazoo.client import KazooClient
 
 from pykafka import KafkaClient
 from pykafka.balancedconsumer import BalancedConsumer, OffsetType
-from pykafka.exceptions import NoPartitionsForConsumerException, ConsumerStoppedException
+from pykafka.exceptions import ConsumerStoppedException
 from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import range, iterkeys, iteritems
 
@@ -264,8 +264,8 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         consumer._decide_partitions = lambda p: set()
         consumer.start()
         self.assertFalse(consumer._running)
-        with self.assertRaises(NoPartitionsForConsumerException):
-            consumer.consume()
+        res = consumer.consume()
+        self.assertEqual(res, None)
 
     def test_zk_conn_lost(self):
         """Check we restore zookeeper nodes correctly after connection loss

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -255,11 +255,12 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         consumer.stop()
 
     def test_no_partitions(self):
-        """Ensure a consumer assigned no partitions returns None on consume()"""
+        """Ensure a consumer assigned no partitions doesn't fail"""
         consumer = self.client.topics[self.topic_name].get_balanced_consumer(
             b'test_no_partitions',
             zookeeper_connect=self.kafka.zookeeper,
             auto_start=False,
+            consumer_timeout_ms=50,
             use_rdkafka=self.USE_RDKAFKA)
         consumer._decide_partitions = lambda p: set()
         consumer.start()

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -263,10 +263,10 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
             use_rdkafka=self.USE_RDKAFKA)
         consumer._decide_partitions = lambda p: set()
         consumer.start()
-        self.assertFalse(consumer._running)
         res = consumer.consume()
         self.assertEqual(res, None)
         self.assertTrue(consumer._running)
+        # check that stop() succeeds (cf #313 and #392)
         consumer.stop()
 
     def test_zk_conn_lost(self):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -255,7 +255,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         consumer.stop()
 
     def test_no_partitions(self):
-        """Ensure a consumer assigned no partitions immediately exits"""
+        """Ensure a consumer assigned no partitions returns None on consume()"""
         consumer = self.client.topics[self.topic_name].get_balanced_consumer(
             b'test_no_partitions',
             zookeeper_connect=self.kafka.zookeeper,
@@ -266,6 +266,8 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         self.assertFalse(consumer._running)
         res = consumer.consume()
         self.assertEqual(res, None)
+        self.assertTrue(consumer._running)
+        consumer.stop()
 
     def test_zk_conn_lost(self):
         """Check we restore zookeeper nodes correctly after connection loss


### PR DESCRIPTION
The `NoPartitionsForConsumer` exception is usually raised when it shouldn't be. This pull request fixes #391 by having the consumer return `None` instead of raising this exception.