### PR TITLE
message enqueue filtering

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -816,7 +816,7 @@ class OwnedPartition(object):
         :type messages: Iterable of :class:`pykafka.common.Message`
         """
         for message in messages:
-            if message.offset < self.last_offset_consumed:
+            if message.offset <= self.last_offset_consumed:
                 log.debug("Skipping enqueue for offset (%s) "
                           "less than last_offset_consumed (%s)",
                           message.offset, self.last_offset_consumed)

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -816,10 +816,10 @@ class OwnedPartition(object):
         :type messages: Iterable of :class:`pykafka.common.Message`
         """
         for message in messages:
-            if message.offset <= self.last_offset_consumed:
+            if message.offset != self.next_offset:
                 log.debug("Skipping enqueue for offset (%s) "
-                          "less than last_offset_consumed (%s)",
-                          message.offset, self.last_offset_consumed)
+                          "not equal to next_offset (%s)",
+                          message.offset, self.next_offset)
                 continue
             message.partition = self.partition
             if message.partition_id != self.partition.id:

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -720,7 +720,7 @@ class OwnedPartition(object):
         self.partition = partition
         self._messages = Queue()
         self._messages_arrived = semaphore
-        self.last_offset_consumed = 0
+        self.last_offset_consumed = -1
         self.next_offset = 0
         self.fetch_lock = threading.RLock()
 

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -201,13 +201,15 @@ class TestSimpleConsumer(unittest2.TestCase):
 
 class TestOwnedPartition(unittest2.TestCase):
     def test_partition_saves_offset(self):
+        offset = 20
         msgval = "test"
         partition = mock.MagicMock()
         op = OwnedPartition(partition)
+        op.next_offset = offset
 
         message = mock.Mock()
         message.value = msgval
-        message.offset = 20
+        message.offset = offset
 
         op.enqueue_messages([message])
         self.assertEqual(op.message_count, 1)


### PR DESCRIPTION
This pull request ensures that the `SimpleConsumer` doesn't re-enqueue the last message it consumed. It fixes #389.

It's not entirely clear to me at the moment if there's some other logic error in the consumer initialization offset logic, but this at least appears to be a real bug and does actually fix #389.