### PR TITLE
handle RequestTimedOut

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -35,7 +35,7 @@ from .exceptions import (OffsetOutOfRangeError, UnknownTopicOrPartition,
                          NotCoordinatorForConsumer, SocketDisconnectedError,
                          ConsumerStoppedException, KafkaException,
                          NotLeaderForPartition, OffsetRequestFailedError,
-                         ERROR_CODES)
+                         RequestTimedOut, ERROR_CODES)
 from .protocol import (PartitionFetchRequest, PartitionOffsetCommitRequest,
                        PartitionOffsetFetchRequest, PartitionOffsetRequest)
 from .utils.error_handlers import (handle_partition_responses, raise_error,
@@ -247,6 +247,9 @@ class SimpleConsumer(object):
                                    for owned_partition, pres in parts]
             )
 
+        def _handle_RequestTimedOut(parts):
+            log.info("Continuing in response to RequestTimedOut")
+
         def _handle_NotCoordinatorForConsumer(parts):
             log.info("Updating cluster in response to NotCoordinatorForConsumer")
             self._update()
@@ -260,7 +263,8 @@ class SimpleConsumer(object):
             OffsetOutOfRangeError.ERROR_CODE: _handle_OffsetOutOfRangeError,
             NotLeaderForPartition.ERROR_CODE: _handle_NotLeaderForPartition,
             OffsetMetadataTooLarge.ERROR_CODE: lambda p: raise_error(OffsetMetadataTooLarge),
-            NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer
+            NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer,
+            RequestTimedOut.ERROR_CODE: _handle_RequestTimedOut
         }
 
     def _discover_offset_manager(self):


### PR DESCRIPTION
This pull request adds a no-op handler for `RequestTimedOut` errors to allow the normal retry logic to handle those cases in `SimpleConsumer`. It fixes #401.