### PR TITLE
raise and rename error code 14 GroupLoadInProgress

### DIFF
--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -144,10 +144,11 @@ class OffsetMetadataTooLarge(ProtocolClientError):
     ERROR_CODE = 12
 
 
-class OffsetsLoadInProgress(ProtocolClientError):
+class GroupLoadInProgress(ProtocolClientError):
     """The broker returns this error code for an offset fetch request if it is
         still loading offsets (after a leader change for that offsets topic
-        partition).
+        partition), or in response to group membership requests (such as
+        heartbeats) when group metadata is being loaded by the coordinator.
     """
     ERROR_CODE = 14
 
@@ -178,7 +179,7 @@ ERROR_CODES = dict(
                 RequestTimedOut,
                 MessageSizeTooLarge,
                 OffsetMetadataTooLarge,
-                OffsetsLoadInProgress,
+                GroupLoadInProgress,
                 ConsumerCoordinatorNotAvailable,
                 NotCoordinatorForConsumer)
 )

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -31,7 +31,7 @@ from .common import OffsetType
 from .utils.compat import (Semaphore, Queue, Empty, iteritems, itervalues,
                            range, iterkeys)
 from .exceptions import (OffsetOutOfRangeError, UnknownTopicOrPartition,
-                         OffsetMetadataTooLarge, OffsetsLoadInProgress,
+                         OffsetMetadataTooLarge, GroupLoadInProgress,
                          NotCoordinatorForConsumer, SocketDisconnectedError,
                          ConsumerStoppedException, KafkaException,
                          NotLeaderForPartition, OffsetRequestFailedError,
@@ -261,7 +261,7 @@ class SimpleConsumer(object):
             NotLeaderForPartition.ERROR_CODE: _handle_NotLeaderForPartition,
             OffsetMetadataTooLarge.ERROR_CODE: lambda p: raise_error(OffsetMetadataTooLarge),
             NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer,
-            OffsetsLoadInProgress.ERROR_CODE: lambda p: raise_error(OffsetsLoadInProgress)
+            GroupLoadInProgress.ERROR_CODE: lambda p: raise_error(GroupLoadInProgress)
         }
 
     def _discover_offset_manager(self):
@@ -516,7 +516,7 @@ class SimpleConsumer(object):
 
             # retry only specific error responses
             to_retry = []
-            to_retry.extend(parts_by_error.get(OffsetsLoadInProgress.ERROR_CODE, []))
+            to_retry.extend(parts_by_error.get(GroupLoadInProgress.ERROR_CODE, []))
             to_retry.extend(parts_by_error.get(NotCoordinatorForConsumer.ERROR_CODE, []))
             reqs = [p.build_offset_fetch_request() for p, _ in to_retry]
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -260,7 +260,8 @@ class SimpleConsumer(object):
             OffsetOutOfRangeError.ERROR_CODE: _handle_OffsetOutOfRangeError,
             NotLeaderForPartition.ERROR_CODE: _handle_NotLeaderForPartition,
             OffsetMetadataTooLarge.ERROR_CODE: lambda p: raise_error(OffsetMetadataTooLarge),
-            NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer
+            NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer,
+            OffsetsLoadInProgress.ERROR_CODE: lambda p: raise_error(OffsetsLoadInProgress)
         }
 
     def _discover_offset_manager(self):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -255,13 +255,16 @@ class SimpleConsumer(object):
             log.info("Updating cluster in response to NotLeaderForPartition")
             self._update()
 
+        def _handle_GroupLoadInProgress(parts):
+            log.info("Continuing in response to GroupLoadInProgress")
+
         return {
             UnknownTopicOrPartition.ERROR_CODE: lambda p: raise_error(UnknownTopicOrPartition),
             OffsetOutOfRangeError.ERROR_CODE: _handle_OffsetOutOfRangeError,
             NotLeaderForPartition.ERROR_CODE: _handle_NotLeaderForPartition,
             OffsetMetadataTooLarge.ERROR_CODE: lambda p: raise_error(OffsetMetadataTooLarge),
             NotCoordinatorForConsumer.ERROR_CODE: _handle_NotCoordinatorForConsumer,
-            GroupLoadInProgress.ERROR_CODE: lambda p: raise_error(GroupLoadInProgress)
+            GroupLoadInProgress.ERROR_CODE: _handle_GroupLoadInProgress
         }
 
     def _discover_offset_manager(self):


### PR DESCRIPTION
Fix for #409.

Docs now refer to code 14 as GroupLoadInProgress. So that has been changed.

https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ErrorCodes

The retry logic already in place, the exception just needed to be raised