### PR TITLE
Capture and surface the error thrown by post_rebalance_callback

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -551,8 +551,14 @@ class BalancedConsumer(object):
                             old_offsets = (self._consumer.held_offsets
                                            if self._consumer else dict())
                             new_offsets = cns.held_offsets
-                            reset_offsets = self._post_rebalance_callback(
-                                self, old_offsets, new_offsets)
+                            try:
+                                reset_offsets = self._post_rebalance_callback(
+                                    self, old_offsets, new_offsets)
+                            except Exception as ex:
+                                log.exception("post rebalance callback threw an exception")
+                                self._worker_exception = sys.exc_info()
+                                break
+
                             if reset_offsets:
                                 cns.reset_offsets(partition_offsets=[
                                     (cns.partitions[id_], offset) for


### PR DESCRIPTION
If the post_rebalance_callback throws an error, it was not getting reported. This pr wraps it call in a try catch and binds the exception to _worker_exception.


the `try... except Exception:` catchall makes me feel dirty, but i don't know what else to do. Any suggestions appreciated.