### PR TITLE
get_offset_manager return failure

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -364,6 +364,8 @@ class Cluster(object):
                 log.error("Socket disconnected during offset manager "
                           "discovery. This can happen when using PyKafka "
                           "with a Kafka version lower than 0.8.2.")
+                if i == MAX_RETRIES - 1:
+                    raise
                 self.update()
             else:
                 coordinator = self.brokers.get(res.coordinator_id, None)


### PR DESCRIPTION
This pull request fixes #402 by removing a case in which `get_offset_manager` could return `None`. Specifically, this case occurs when `SocketDisconnectedError` is encountered on the last retry of the loop.