### PR TITLE
Zookeeper connection hangs

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -222,8 +222,8 @@ class Cluster(object):
         :type broker_connects: Iterable of two-element sequences of the format
             (broker_host, broker_port)
         """
-        try:
-            for host, port in broker_connects:
+        for host, port in broker_connects:
+            try:
                 broker = Broker(-1, host, int(port), self._handler,
                                 self._socket_timeout_ms,
                                 self._offsets_channel_socket_timeout_ms,
@@ -233,9 +233,9 @@ class Cluster(object):
                 response = broker.request_metadata(topics)
                 if response is not None:
                     return response
-        except Exception as e:
-            log.error('Unable to connect to broker %s:%s', host, port)
-            log.exception(e)
+            except Exception as e:
+                log.error('Unable to connect to broker %s:%s. Continuing.', host, port)
+                log.exception(e)
 
     def _get_metadata(self, topics=None):
         """Get fresh cluster metadata from a broker."""
@@ -256,7 +256,8 @@ class Cluster(object):
                 return metadata
 
             # try treating seed_hosts as a zookeeper host list
-            zookeeper = KazooClient(self._seed_hosts, timeout=self._socket_timeout_ms)
+            zookeeper = KazooClient(self._seed_hosts,
+                                    timeout=self._socket_timeout_ms / 1000)
             try:
                 zookeeper.start()
             except Exception as e:


### PR DESCRIPTION
This pull request fixes #414 by fixing three different small bugs that interact with each other. First, the timeout provided to `KazooClient` should be in seconds, not milliseconds. Second, the exception handling logic in `_request_metadata` caused that function to fail out as soon as its first attempt to get metadata from a broker failed, effectively rendering the loop useless.

Third and most confusingly, this pull request adds a custom timeout to our call of `KazooClient.start()`. This timeout is chosen to be exactly `n_brokers * socket_timeout`. This is because internally, `KazooClient` actually uses the timeout provided to `__init__` and the one provided to `start` in tandem. The `__init__` kwarg is closer to "socket timeout" - each request to a host carries this timeout value. The `start` timeout, on the other hand, is not directly related to socket communication - instead it's treated as an upper time limit on how long `start` may spend attempting to connect to various different hosts, possibly multiple times. By setting this kwarg to exactly `n_brokers * socket_timeout`, we ensure that, like the first part of `_request_metadata`, this section may only take that long in attempting to connect to each host once.