### PR TITLE
Fixed linger_ms to match documentation.

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -509,7 +509,8 @@ class OwnedBroker(object):
             with self.lock:
                 if len(self.queue) < self.producer._min_queued_messages:
                     self.flush_ready.clear()
-            self.flush_ready.wait((linger_ms / 1000) if linger_ms > 0 else None)
+            if linger_ms > 0:
+                self.flush_ready.wait((linger_ms / 1000))
 
     def _wait_for_slot_available(self):
         """Block until the queue has at least one slot not containing a message"""


### PR DESCRIPTION
`self.flush_ready.wait(None)` will actually linger forever until the `flush_ready` condition is notified. The documentation for linger_ms specifies that a linger_ms of 0 will not linger.