### PR TITLE
Update setup.py gevent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,21 @@ notifications:
     - yungchin@yungchin.nl
 
 install:
-    - pip install codecov kazoo tox testinstances tox-travis gevent==1.1b6
+    - |
+        if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+          export PYENV_ROOT="$HOME/.pyenv"
+          if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+            pushd "$PYENV_ROOT" && git pull && popd
+          else
+            rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+          fi
+          export PYPY_VERSION="4.0.1"
+          "$PYENV_ROOT/bin/pyenv" install --skip-existing "pypy-$PYPY_VERSION"
+          virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+          source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+        fi
+    - pip install -U pip setuptools
+    - pip install codecov kazoo tox testinstances tox-travis "gevent>=1.1b6,<1.2"
     - wget https://github.com/edenhill/librdkafka/archive/0.8.6.tar.gz
     - tar -xzf 0.8.6.tar.gz
     - cd librdkafka-0.8.6/ && ./configure --prefix=$HOME

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_version():
 install_requires = [
     'kazoo',
     'tabulate',
-    'gevent==1.1b6'
+    'gevent>=1.1b6,<1.2'
 ]
 
 lint_requires = [


### PR DESCRIPTION
Update the setup.py so that the gevent version is not fixed to a beta release.

This should help compatibility with projects using gevent which do not fix versions to a beta version and keep gevent more up to date with 1.1 changes (RC, release and post-release).