### PR TITLE
Don't fail on NoNodeError when fetching broker info from ZooKeeper

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -24,6 +24,7 @@ import random
 import time
 import weakref
 
+import kazoo.exceptions
 from kazoo.client import KazooClient
 
 from .broker import Broker
@@ -302,8 +303,11 @@ class Cluster(object):
                 broker_ids = zookeeper.get_children(brokers_path)
                 broker_connects = []
                 for broker_id in broker_ids:
-                    broker_json, _ = zookeeper.get("{}{}".format(brokers_path,
-                                                                 broker_id))
+                    try:
+                        broker_json, _ = zookeeper.get("{}{}".format(brokers_path,
+                                                                     broker_id))
+                    except kazoo.exceptions.NoNodeError:
+                        continue
                     broker_info = json.loads(broker_json.decode("utf-8"))
                     broker_connects.append((broker_info['host'],
                                             broker_info['port']))


### PR DESCRIPTION
Hi. Some minor fix for the following error here.

```
ERROR [pykafka.cluster] Unable to fetch broker info from ZooKeeper
ERROR [pykafka.cluster] ((), {})
Traceback (most recent call last):
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 306, in _get_brokers_from_zookeeper
    broker_id))
  File "/home/alonger/env/lib/python2.7/site-packages/kazoo/client.py", line 1026, in get
    return self.get_async(path, watch).get()
  File "/home/alonger/env/lib/python2.7/site-packages/kazoo/handlers/utils.py", line 78, in get
    raise self._exception
NoNodeError: ((), {})
Traceback (most recent call last):
  File "producer.py", line 55, in <module>
    topic = client.topics[args.topic]
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 59, in __getitem__
    topic_ref = super(TopicDict, self).__getitem__(key)
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 79, in __missing__
    self._create_topic(key)
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 99, in _create_topic
    res = self._cluster()._get_metadata(topics=[topic_name])
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 256, in _get_metadata
    metadata = self._request_metadata(broker_connects, topics)
  File "/home/alonger/env/lib/python2.7/site-packages/pykafka/cluster.py", line 228, in _request_metadata
    for host, port in broker_connects:
TypeError: 'NoneType' object is not iterable
```

Thanks.