### PR TITLE
sync producer worker hang

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -29,6 +29,7 @@ from kazoo.client import KazooClient
 from .broker import Broker
 from .exceptions import (ERROR_CODES,
                          ConsumerCoordinatorNotAvailable,
+                         NoBrokersAvailableError,
                          SocketDisconnectedError,
                          LeaderNotAvailable)
 from .protocol import ConsumerMetadataRequest, ConsumerMetadataResponse
@@ -271,7 +272,7 @@ class Cluster(object):
                     return metadata
 
         # Couldn't connect anywhere. Raise an error.
-        raise RuntimeError(
+        raise NoBrokersAvailableError(
             'Unable to connect to a broker to fetch metadata. See logs.')
 
     def _get_brokers_from_zookeeper(self, zk_connect):

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -23,6 +23,12 @@ class KafkaException(Exception):
     pass
 
 
+class NoBrokersAvailableError(KafkaException):
+    """Indicates that no brokers were available to the cluster's metadata update attempts
+    """
+    pass
+
+
 class SocketDisconnectedError(KafkaException):
     """Indicates that the socket connecting this client to a kafka broker has
         become disconnected

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -31,6 +31,7 @@ from .exceptions import (
     KafkaException,
     InvalidMessageSize,
     MessageSizeTooLarge,
+    NoBrokersAvailableError,
     NotLeaderForPartition,
     ProducerQueueFullError,
     ProducerStoppedException,
@@ -364,7 +365,10 @@ class Producer(object):
             log.warning('Broker %s:%s disconnected. Retrying.',
                         owned_broker.broker.host,
                         owned_broker.broker.port)
-            self._update()
+            try:
+                self._update()
+            except NoBrokersAvailableError:
+                log.warning("No brokers available")
             to_retry = [
                 (mset, exc)
                 for topic, partitions in iteritems(req.msets)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -23,7 +23,6 @@ import logging
 import sys
 import threading
 import traceback
-from Queue import Empty
 import weakref
 
 from .common import CompressionType
@@ -40,7 +39,7 @@ from .exceptions import (
 )
 from .partitioners import random_partitioner
 from .protocol import Message, ProduceRequest
-from .utils.compat import iteritems, range, itervalues
+from .utils.compat import iteritems, range, itervalues, Empty
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request fixes #449 by keeping the producer worker thread alive long enough to fill the delivery report queue for the synchronous check in `produce()`.