### PR TITLE
Remove ZooKeeper fallback

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -264,12 +264,6 @@ class Cluster(object):
                 if metadata is not None:
                     return metadata
 
-                # fall back to zookeeper for backward compatibility
-                broker_connects = self._get_brokers_from_zookeeper(self._seed_hosts)
-                metadata = self._request_metadata(broker_connects, topics)
-                if metadata is not None:
-                    return metadata
-
         # Couldn't connect anywhere. Raise an error.
         raise RuntimeError(
             'Unable to connect to a broker to fetch metadata. See logs.')

--- a/tests/pykafka/test_cluster.py
+++ b/tests/pykafka/test_cluster.py
@@ -59,17 +59,12 @@ class ClusterIntegrationTests(unittest.TestCase):
     def test_zk_connect(self):
         """Clusters started with broker lists and zk connect strings should get same brokers"""
         zk_client = KafkaClient(zookeeper_hosts=self.kafka.zookeeper)
-        # backward compatibility
-        zk_fallback_client = KafkaClient(hosts=self.kafka.zookeeper)
         kafka_client = KafkaClient(hosts=self.kafka.brokers)
         zk_brokers = ["{}:{}".format(b.host, b.port)
                       for b in itervalues(zk_client.brokers)]
-        zk_fallback_brokers = ["{}:{}".format(b.host, b.port)
-                               for b in itervalues(zk_fallback_client.brokers)]
         kafka_brokers = ["{}:{}".format(b.host, b.port)
                          for b in itervalues(kafka_client.brokers)]
         self.assertEqual(zk_brokers, kafka_brokers)
-        self.assertEqual(zk_brokers, zk_fallback_brokers)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #448 by removing the zookeeper fallback in the cluster's broker discovery logic.

This removes a feature from the public interface, so it should not be merged until the next major version bump.