### PR TITLE
unify retry logic in Cluster

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -61,13 +61,13 @@ class TopicDict(dict):
             return topic_ref()
         else:
             # Topic exists, but needs to be instantiated locally
-            for i in range(self._cluster._max_connection_retries):
+            for i in range(self._cluster()._max_connection_retries):
                 meta = self._cluster()._get_metadata([key])
                 try:
                     topic = Topic(self._cluster(), meta.topics[key])
                 except LeaderNotAvailable:
                     log.warning("LeaderNotAvailable encountered during Topic creation")
-                    if i == self._cluster._max_connection_retries - 1:
+                    if i == self._cluster()._max_connection_retries - 1:
                         raise
                 else:
                     self[key] = weakref.ref(topic)

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -61,14 +61,13 @@ class TopicDict(dict):
             return topic_ref()
         else:
             # Topic exists, but needs to be instantiated locally
-            max_retries = 3
-            for i in range(max_retries):
+            for i in range(self._cluster._max_connection_retries):
                 meta = self._cluster()._get_metadata([key])
                 try:
                     topic = Topic(self._cluster(), meta.topics[key])
                 except LeaderNotAvailable:
                     log.warning("LeaderNotAvailable encountered during Topic creation")
-                    if i == max_retries - 1:
+                    if i == self._cluster._max_connection_retries - 1:
                         raise
                 else:
                     self[key] = weakref.ref(topic)
@@ -189,6 +188,7 @@ class Cluster(object):
         self._source_host = self._source_address.split(':')[0]
         self._source_port = 0
         self._zookeeper_connect = zookeeper_hosts
+        self._max_connection_retries = 3
         if ':' in self._source_address:
             self._source_port = int(self._source_address.split(':')[1])
         self.update()
@@ -225,20 +225,21 @@ class Cluster(object):
         :type broker_connects: Iterable of two-element sequences of the format
             (broker_host, broker_port)
         """
-        for host, port in broker_connects:
-            try:
-                broker = Broker(-1, host, int(port), self._handler,
-                                self._socket_timeout_ms,
-                                self._offsets_channel_socket_timeout_ms,
-                                buffer_size=1024 * 1024,
-                                source_host=self._source_host,
-                                source_port=self._source_port)
-                response = broker.request_metadata(topics)
-                if response is not None:
-                    return response
-            except Exception as e:
-                log.error('Unable to connect to broker %s:%s. Continuing.', host, port)
-                log.exception(e)
+        for i in range(self._max_connection_retries):
+            for host, port in broker_connects:
+                try:
+                    broker = Broker(-1, host, int(port), self._handler,
+                                    self._socket_timeout_ms,
+                                    self._offsets_channel_socket_timeout_ms,
+                                    buffer_size=1024 * 1024,
+                                    source_host=self._source_host,
+                                    source_port=self._source_port)
+                    response = broker.request_metadata(topics)
+                    if response is not None:
+                        return response
+                except Exception as e:
+                    log.error('Unable to connect to broker %s:%s. Continuing.', host, port)
+                    log.exception(e)
 
     def _get_metadata(self, topics=None):
         """Get fresh cluster metadata from a broker."""
@@ -290,8 +291,9 @@ class Cluster(object):
             # self._socket_timeout_ms equal to the number of hosts. This provides
             # the same retrying behavior that pykafka uses above when treating
             # this host string as a list of kafka brokers.
-            zookeeper.start(
-                timeout=(len(zk_connect.split(',')) * self._socket_timeout_ms) / 1000)
+            timeout = (len(zk_connect.split(',')) * self._max_connection_retries *
+                       self._socket_timeout_ms) / 1000
+            zookeeper.start(timeout=timeout)
         except Exception as e:
             log.error('Unable to connect to ZooKeeper instance %s', zk_connect)
             log.exception(e)
@@ -376,9 +378,8 @@ class Cluster(object):
                  consumer_group)
         # arbitrarily choose a broker, since this request can go to any
         broker = self.brokers[random.choice(list(self.brokers.keys()))]
-        MAX_RETRIES = 5
 
-        for i in range(MAX_RETRIES):
+        for i in range(self._max_connection_retries):
             if i > 0:
                 log.debug("Retrying offset manager discovery")
             time.sleep(i * 2)
@@ -389,13 +390,13 @@ class Cluster(object):
                 res = future.get(ConsumerMetadataResponse)
             except ConsumerCoordinatorNotAvailable:
                 log.error('Error discovering offset manager.')
-                if i == MAX_RETRIES - 1:
+                if i == self._max_connection_retries - 1:
                     raise
             except SocketDisconnectedError:
                 log.error("Socket disconnected during offset manager "
                           "discovery. This can happen when using PyKafka "
                           "with a Kafka version lower than 0.8.2.")
-                if i == MAX_RETRIES - 1:
+                if i == self._max_connection_retries - 1:
                     raise
                 self.update()
             else:
@@ -407,8 +408,7 @@ class Cluster(object):
 
     def update(self):
         """Update known brokers and topics."""
-        max_retries = 3
-        for i in range(max_retries):
+        for i in range(self._max_connection_retries):
             metadata = self._get_metadata()
             if len(metadata.brokers) == 0 and len(metadata.topics) == 0:
                 log.warning('No broker metadata found. If this is a fresh cluster, '


### PR DESCRIPTION
This pull request addresses #428 by adding some rudimentary connection retrying logic to the metadata fetching section of broker discover. It also unifies the timeouts used between the zookeeper and kafka broker discovery methods and uses a single member attribute to keep track of the retry limit for each component of `Cluster`.