### PR TITLE
GroupLoadInProgress exception

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -530,6 +530,9 @@ class SimpleConsumer(object):
             to_retry.extend(parts_by_error.get(NotCoordinatorForConsumer.ERROR_CODE, []))
             reqs = [p.build_offset_fetch_request() for p, _ in to_retry]
 
+        if parts_by_error.get(GroupLoadInProgress.ERROR_CODE, []):
+            raise GroupLoadInProgress()
+
     def reset_offsets(self, partition_offsets=None):
         """Reset offsets for the specified partitions
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -524,14 +524,11 @@ class SimpleConsumer(object):
 
             self._cluster.handler.sleep(i * (self._offsets_channel_backoff_ms / 1000))
 
-            # retry only specific error responses
-            to_retry = []
-            to_retry.extend(parts_by_error.get(GroupLoadInProgress.ERROR_CODE, []))
-            to_retry.extend(parts_by_error.get(NotCoordinatorForConsumer.ERROR_CODE, []))
+            to_retry = [pair for err in itervalues(parts_by_error) for pair in err]
             reqs = [p.build_offset_fetch_request() for p, _ in to_retry]
 
-        if parts_by_error.get(GroupLoadInProgress.ERROR_CODE, []):
-            raise GroupLoadInProgress()
+        if len(parts_by_error) > 1:
+            raise KafkaException(parts_by_error)
 
     def reset_offsets(self, partition_offsets=None):
         """Reset offsets for the specified partitions


### PR DESCRIPTION
This pull request fixes #396 by raising an exception when `GroupLoadInProgress` is returned from an offset fetch after the maximum number of retries. I can't think of any cases in which it's actually beneficial for the consumer not to find its previously stored offsets if `reset_offsets_on_start=False`, which means I'm probably forgetting something. This change is up for discussion.