### PR TITLE
[WIP] Compacted topic 'Skipping enqueue for offset' error

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -213,7 +213,7 @@ class BalancedConsumer(object):
         self._running = False
         self._worker_exception = None
         self._worker_trace_logged = False
-        self._compacted_topic = compacted_topic
+        self._is_compacted_topic = compacted_topic
 
         if not rdkafka and use_rdkafka:
             raise ImportError("use_rdkafka requires rdkafka to be installed")
@@ -378,7 +378,7 @@ class BalancedConsumer(object):
             auto_offset_reset=self._auto_offset_reset,
             reset_offset_on_start=reset_offset_on_start,
             auto_start=start,
-            compacted_topic=self._compacted_topic
+            compacted_topic=self._is_compacted_topic
         )
 
     def _decide_partitions(self, participants):

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -90,7 +90,8 @@ class BalancedConsumer(object):
                  auto_start=True,
                  reset_offset_on_start=False,
                  post_rebalance_callback=None,
-                 use_rdkafka=False):
+                 use_rdkafka=False,
+                 compacted_topic=False):
         """Create a BalancedConsumer instance
 
         :param topic: The topic this consumer should consume
@@ -181,6 +182,10 @@ class BalancedConsumer(object):
         :type post_rebalance_callback: function
         :param use_rdkafka: Use librdkafka-backed consumer if available
         :type use_rdkafka: bool
+        :param compacted_topic: Set to read from a compacted topic. Forces
+            consumer to use less stringent ordering logic when because compacted
+            topics do not provide offsets in stict incrementing order.
+        :type compacted_topic: bool
         """
         self._cluster = cluster
         if not isinstance(consumer_group, bytes):
@@ -208,6 +213,7 @@ class BalancedConsumer(object):
         self._running = False
         self._worker_exception = None
         self._worker_trace_logged = False
+        self._compacted_topic = compacted_topic
 
         if not rdkafka and use_rdkafka:
             raise ImportError("use_rdkafka requires rdkafka to be installed")
@@ -371,7 +377,8 @@ class BalancedConsumer(object):
             offsets_commit_max_retries=self._offsets_commit_max_retries,
             auto_offset_reset=self._auto_offset_reset,
             reset_offset_on_start=reset_offset_on_start,
-            auto_start=start
+            auto_start=start,
+            compacted_topic=self._compacted_topic
         )
 
     def _decide_partitions(self, participants):

--- a/pykafka/rdkafka/simple_consumer.py
+++ b/pykafka/rdkafka/simple_consumer.py
@@ -44,7 +44,8 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
                  auto_offset_reset=OffsetType.EARLIEST,
                  consumer_timeout_ms=-1,
                  auto_start=True,
-                 reset_offset_on_start=False):
+                 reset_offset_on_start=False,
+                 compacted_topic=False):
         callargs = {k: v for k, v in vars().items()
                          if k not in ("self", "__class__")}
         self._rdk_consumer = None

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -839,7 +839,8 @@ class OwnedPartition(object):
                 self.next_offset = message.offset
                 self._consumed_first_msg = True
 
-            if message.offset != self.next_offset:
+            # enforce ordering of messages
+            if message.offset < self.next_offset:
                 log.debug("Skipping enqueue for offset (%s) "
                           "not equal to next_offset (%s)",
                           message.offset, self.next_offset)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ tests_require = [
 ]
 
 dependency_links = []
-
 setup_requires = []
 
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ tests_require = [
 ]
 
 dependency_links = []
+
 setup_requires = []
 
 

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -228,7 +228,21 @@ class TestOwnedPartition(unittest2.TestCase):
         self.assertNotEqual(ret_message, None)
         self.assertEqual(ret_message.value, msgval)
 
-    def test_partition_rejects_old_message_after_initial(self):
+    def test_partition_rejects_old_message(self):
+        last_offset = 400
+        op = OwnedPartition(None)
+        op.last_offset_consumed = last_offset
+
+        message = mock.Mock()
+        message.value = "test"
+        message.offset = 20
+
+        op.enqueue_messages([message])
+        self.assertEqual(op.message_count, 0)
+        op.consume()
+        self.assertEqual(op.last_offset_consumed, last_offset)
+
+    def test_compacted_topic_partition_rejects_old_message_after_initial(self):
         last_offset = 400
         message1 = mock.Mock()
         message1.value = "first-test"
@@ -237,7 +251,7 @@ class TestOwnedPartition(unittest2.TestCase):
 
         partition = mock.MagicMock()
         partition.id = 0
-        op = OwnedPartition(partition)
+        op = OwnedPartition(partition, compacted_topic=True)
         op.enqueue_messages([message1])
         self.assertEqual(op.message_count, 1)
         consumed_msg = op.consume()


### PR DESCRIPTION
This is an incomplete PR. but i wanted to get a conversation started around this. 

I am reading from a compacted topic. Kafka compaction guarantees that the offset are increasing but not strictly incrementing. Two issues:

1. kafka reports earliest available offset as 0. So the next_offset is set to 0. the first message is a some offset much higher and all messages are discarded by `if message.offset != self.next_offset:`

Here is the output from the admin tools:

```
bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list
kafka01:9092 --topic compactedtopic --time -2
compactedtopic:0:0
compactedtopic:1:0
```
and actually pulling from that topic/partition (using kafkacat):
```
kafkacat -b kafka01 -C -t compactedtopic -p 0 -f 'Topic[%p], offset: %o,
key: %k\n' -c 3
Topic[0], offset: 151866, key: key1
Topic[0], offset: 151867, key: key2
Topic[0], offset: 151869, key: key3
```
When i pull from this topic using pykafka i get:
```
DEBUG:pykafka.simpleconsumer:Skipping enqueue for offset (151866) not equal to next_offset (0)
DEBUG:pykafka.simpleconsumer:Skipping enqueue for offset (151867) not equal to next_offset (0)
DEBUG:pykafka.simpleconsumer:Skipping enqueue for offset (151869) not equal to next_offset (0)
```
What complicates this even more then just the starting offset. A compacted log will not increment offsets. Note the jump from 151867 -> 151869.

This PR is a hack to deal with starting offset problem, however the non incrementing nature of compacted logs will require much more significant changes to the enque_messages method.

Any thoughts on how to tackle this?