### PR TITLE
gracefuly stop producer via joining OwnedBroker.queue_reader threads

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -81,7 +81,7 @@ class ThreadingHandler(Handler):
     Event = threading.Event
     Lock = threading.Lock
     Semaphore = Semaphore
-    _maxCount = 0
+    _workers_spawned = 0
 
     def sleep(self, seconds=0):
         time.sleep(seconds)
@@ -97,11 +97,11 @@ class ThreadingHandler(Handler):
 
     def spawn(self, target, *args, **kwargs):
         if 'name' in kwargs:
-            kwargs['name'] = "{}: {}".format(ThreadingHandler._maxCount, kwargs['name'])
+            kwargs['name'] = "{}: {}".format(ThreadingHandler._workers_spawned, kwargs['name'])
         t = threading.Thread(target=target, *args, **kwargs)
         t.daemon = True
         t.start()
-        ThreadingHandler._maxCount += 1
+        ThreadingHandler._workers_spawned += 1
         return t
 
 

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -81,6 +81,7 @@ class ThreadingHandler(Handler):
     Event = threading.Event
     Lock = threading.Lock
     Semaphore = Semaphore
+    _maxCount = 0
 
     def sleep(self, seconds=0):
         time.sleep(seconds)
@@ -95,9 +96,12 @@ class ThreadingHandler(Handler):
             return threading.RLock(*args[1:], **kwargs)
 
     def spawn(self, target, *args, **kwargs):
+        if 'name' in kwargs:
+            kwargs['name'] = "{}: {}".format(ThreadingHandler._maxCount, kwargs['name'])
         t = threading.Thread(target=target, *args, **kwargs)
         t.daemon = True
         t.start()
+        ThreadingHandler._maxCount += 1
         return t
 
 
@@ -113,6 +117,9 @@ class GEventHandler(Handler):
         gevent.sleep(seconds)
 
     def spawn(self, target, *args, **kwargs):
+        # Greenlets don't support naming
+        if 'name' in kwargs:
+            kwargs.pop('name')
         t = gevent.spawn(target, *args, **kwargs)
         return t
 

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -193,4 +193,6 @@ class RequestHandler(object):
                     shared.requests.task_done()
             log.info("RequestHandler worker: exiting cleanly")
 
-        return self.handler.spawn(worker)
+        return self.handler.spawn(worker, name="pykafka.RequestHandler.worker for {}:{}".format(
+                                            self.shared.connection.host,
+                                            self.shared.connection.port))

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -237,25 +237,29 @@ class Producer(object):
             for owned_broker in self._owned_brokers.values():
                 owned_broker.stop()
 
+    def get_queue_readers(self):
+            return [owned_broker._queue_reader_worker for owned_broker in self._owned_brokers.values() if owned_broker.running]
+
     def stop(self, wait=True):
         """Mark the producer as stopped, and wait until all messages to be sent
+
+        The join here works because new queue readers are spawned during the execution of the old ones i.e:
+        After a queue reader in its call to producer._send_request encounters either a SocketDisconnectedError or
+        NotLeaderForPartition.ERROR_CODE it updates the cluster, sets up owned brokers thus starting new queue reader
+        threads. Because of this when we call self.get_queue_readers, we get the newly created queue readers, and so try
+        to stop and join them etc ... until they all stop without encountering problems in producer._send_request
 
         :param wait: whether we should wait until all messages to be sent or not
         :type wait: bool
         """
-        def get_queue_readers():
-            return [qr for qr in threading.enumerate() if qr.name.find('pykafka.OwnedBroker.queue_reader') == 0]
-
         while wait and self._running:
+            queue_readers = self.get_queue_readers()
             self._stop_owned_brokers()
-            readers = get_queue_readers()
-            if len(readers):
-                for reader in readers:
-                    reader.join()
+            if len(queue_readers) == 0:
+                self._running = False
             else:
-                break
-
-        self._running = False
+                for queue_reader in queue_readers:
+                    queue_reader.join()
 
     def produce(self, message, partition_key=None):
         """Produce a message.
@@ -466,7 +470,7 @@ class OwnedBroker(object):
             log.info("Worker exited for broker %s:%s", self.broker.host,
                      self.broker.port)
         log.info("Starting new produce worker for broker %s", broker.id)
-        self.producer._cluster.handler.spawn(queue_reader,
+        self._queue_reader_worker = self.producer._cluster.handler.spawn(queue_reader,
                                              name="pykafka.OwnedBroker.queue_reader for broker %d" % self.broker.id)
 
     def stop(self):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -238,7 +238,9 @@ class Producer(object):
                 owned_broker.stop()
 
     def get_queue_readers(self):
-            return [owned_broker._queue_reader_worker for owned_broker in self._owned_brokers.values() if owned_broker.running]
+        if not self._owned_brokers:
+            return []
+        return [owned_broker._queue_reader_worker for owned_broker in self._owned_brokers.values() if owned_broker.running]
 
     def stop(self, wait=True):
         """Mark the producer as stopped, and wait until all messages to be sent

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -331,7 +331,7 @@ class SimpleConsumer(object):
                     break
             log.debug("Autocommitter thread exiting")
         log.debug("Starting autocommitter thread")
-        return self._cluster.handler.spawn(autocommitter)
+        return self._cluster.handler.spawn(autocommitter, name="pykafka.SimpleConsumer.autocommiter")
 
     def _setup_fetch_workers(self):
         """Start the fetcher threads"""
@@ -353,7 +353,7 @@ class SimpleConsumer(object):
                     break
             log.debug("Fetcher thread exiting")
         log.info("Starting %s fetcher threads", self._num_consumer_fetchers)
-        return [self._cluster.handler.spawn(fetcher)
+        return [self._cluster.handler.spawn(fetcher, name="pykafka.SimpleConsumer.fetcher")
                 for i in range(self._num_consumer_fetchers)]
 
     def __iter__(self):

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -137,7 +137,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
             start = time.time()
             producer.produce(uuid4().bytes)
             producer.produce(uuid4().bytes)
-        self.assertEqual(int(time.time() - start), int(linger))
+        self.assertTrue(int(time.time() - start) > int(linger))
         self.consumer.consume()
         self.consumer.consume()
 


### PR DESCRIPTION
I've found a solution to my problem (https://github.com/Parsely/pykafka/issues/457) with the producer exiting early on producer.stop() and forgetting to send messages that originally targeted a kafka broker which went down.

Simply by naming the threads, filtering them and joining them in the producer.stop() method I was able to achieve a graceful shut-down.

While at it I also added names to all the threads I've found.