### PR TITLE
Consumers expect bytes for consumer group names

### DIFF
--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -171,7 +171,7 @@ class Topic(object):
         """Return a SimpleConsumer of this topic
 
         :param consumer_group: The name of the consumer group to join
-        :type consumer_group: str
+        :type consumer_group: bytes
         :param use_rdkafka: Use librdkafka-backed consumer if available
         :type use_rdkafka: bool
         """
@@ -190,7 +190,7 @@ class Topic(object):
         """Return a BalancedConsumer of this topic
 
         :param consumer_group: The name of the consumer group to join
-        :type consumer_group: str
+        :type consumer_group: bytes
         """
         if "zookeeper_connect" not in kwargs and \
                 self._cluster._zookeeper_connect is not None:


### PR DESCRIPTION
[`SimpleConsumer`](https://github.com/Parsely/pykafka/blob/c3a4b5b5eecc8d8ebd9a1eed58361766cabebd66/pykafka/simpleconsumer.py#L84)s and [`BalancedConsumer`](https://github.com/Parsely/pykafka/blob/c3a4b5b5eecc8d8ebd9a1eed58361766cabebd66/pykafka/balancedconsumer.py#L102)s both expect `bytes` for the `consumer_group`, so we should have the type as `bytes` when getting a simple or balanced consumer for a topic.