### PR TITLE
__del__ should only stop consumer if it is running

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -244,7 +244,8 @@ class BalancedConsumer(object):
 
     def __del__(self):
         log.debug("Finalising {}".format(self))
-        self.stop()
+        if self._running:
+            self.stop()
 
     def __repr__(self):
         return "<{module}.{name} at {id_} (consumer_group={group})>".format(

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -311,7 +311,8 @@ class SimpleConsumer(object):
     def __del__(self):
         """Stop consumption and workers when object is deleted"""
         log.debug("Finalising {}".format(self))
-        self.stop()
+        if self._running:
+            self.stop()
 
     def stop(self):
         """Flag all running workers for deletion."""


### PR DESCRIPTION
Ran into this error when attempting to gracefully shutdown my application.  What happens is when `__del__` gets called (I believe when the GC is cleaning up) and the consumer has already been stopped then your application hangs (using python 3.5.1).  Here is an example of what you see when the consumer hangs (notice how the consumer's stop method is called twice - expectation is once):
```
DEBUG [2016-02-24 15:41:20,334] stop: Stopping <pykafka.balancedconsumer.BalancedConsumer at 0x7f7762b25710 (consumer_group=b'nathanhale')>
DEBUG [2016-02-24 15:41:20,335] commit_offsets: Committing offsets for 3 partitions to broker id 0
DEBUG [2016-02-24 15:41:20,337] _submit: Sending request(xid=13): Close()
DEBUG [2016-02-24 15:41:20,339] _read_watch_event: Received EVENT: Watch(type=4, state=3, path="/consumers/b'nathanhale'/ids")
INFO [2016-02-24 15:41:20,340] _connect_attempt: Closing connection to localhost:2181
INFO [2016-02-24 15:41:20,340] _session_callback: Zookeeper session lost, state: CLOSED
DEBUG [2016-02-24 15:41:20,341] __del__: Finalising <pykafka.balancedconsumer.BalancedConsumer at 0x7f7762b25710 (consumer_group=b'nathanhale')>
DEBUG [2016-02-24 15:41:20,341] stop: Stopping <pykafka.balancedconsumer.BalancedConsumer at 0x7f7762b25710 (consumer_group=b'nathanhale')>
DEBUG [2016-02-24 15:41:20,341] commit_offsets: Committing offsets for 3 partitions to broker id 0
*** this is where it hangs...
```
And this is what you get with the fix (stop is now called once):
```
DEBUG [2016-02-24 15:52:05,508] stop: Stopping <pykafka.balancedconsumer.BalancedConsumer at 0x7f29634697f0 (consumer_group=b'nathanhale')>
DEBUG [2016-02-24 15:52:05,508] commit_offsets: Committing offsets for 3 partitions to broker id 0
DEBUG [2016-02-24 15:52:05,511] _submit: Sending request(xid=13): Close()
DEBUG [2016-02-24 15:52:05,513] _read_watch_event: Received EVENT: Watch(type=4, state=3, path="/consumers/b'nathanhale'/ids")
INFO [2016-02-24 15:52:05,514] _connect_attempt: Closing connection to localhost:2181
INFO [2016-02-24 15:52:05,514] _session_callback: Zookeeper session lost, state: CLOSED
```
Note that calling the consumer's stop method twice does not seem the hang consumer so the change to `__del__` should be sufficient to address this bug I think.

I'm not 100% sure this is the best solution so let me know if there would be a better way to solve this issue and I can make those changes.  Since this is a minor change I am submitting to master (I did read the guidelines ;P).