### PR TITLE
Fix dependency on gevent to get pykafka installing again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_version():
 install_requires = [
     'kazoo',
     'tabulate',
-    'gevent>=1.1b6,<1.2'
+    'gevent ~= 1.1b6'
 ]
 
 lint_requires = [


### PR DESCRIPTION
The pykafka 2.2.1 is not installing in a clean virtualenv at the moment, because it appears to be having some trouble using `>=` and `<` with gevent's release candidate version number scheme. This switches over to `~`, which should be equivalent to what was originally intended, but appears to work with versions
like 1.1rc6. This may need to be revisited once gevent 1.1 actually is released though.