### PR TITLE
Allow user to decide whether log undelivered messages as warnings or errors

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -67,7 +67,8 @@ class Producer(object):
                  linger_ms=5 * 1000,
                  block_on_queue_full=True,
                  sync=False,
-                 delivery_reports=False):
+                 delivery_reports=False,
+                 log_undelivered_as_error=False):
         """Instantiate a new AsyncProducer
 
         :param cluster: The cluster to which to connect
@@ -131,6 +132,10 @@ class Producer(object):
             or an `Exception` in case of failed delivery to kafka.
             This setting is ignored when `sync=True`.
         :type delivery_reports: bool
+        :param log_undelivered_as_error: Whether undelivered messacages (after
+            trying out max_retries) are logged as errors (if True) or warnings
+            (if False, default)
+        :type log_undelivered_as_error: bool
         """
         self._cluster = cluster
         self._topic = topic
@@ -154,6 +159,10 @@ class Producer(object):
         self._running = False
         self._update_lock = self._cluster.handler.Lock()
         self.start()
+        if(log_undelivered_as_error):
+            self.log_undelivered = log.error
+        else:
+            self.log_undelivered = log.warning
 
     def __del__(self):
         log.debug("Finalising {}".format(self))
@@ -431,7 +440,7 @@ class Producer(object):
                 for msg in mset.messages:
                     if (non_recoverable or msg.produce_attempt >= self._max_retries):
                         self._delivery_reports.put(msg, exc)
-                        log.info("Message not delivered!! %r" % exc)
+                        self.log_undelivered("Message not delivered!! %r" % exc)
                     else:
                         msg.produce_attempt += 1
                         self._produce(msg)


### PR DESCRIPTION
I recently ran into an issue with undelivered messages - and noticed I log them only as info - this should be definitely bumped up a notch. On the other hand I can imagine a scenario where you are sending many thousands of messages and don't care much if a few go missing.

So I propose this change to the logging of undelivered messages - user can decide if it should be just a warning (the default) not to overwhelm the logs or an error to really stand out if something goes wrong.