### PR TITLE
depend on newly released gevent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_version():
 install_requires = [
     'kazoo',
     'tabulate',
-    'gevent ~= 1.1b6'
+    'gevent==1.1'
 ]
 
 lint_requires = [


### PR DESCRIPTION
This pull request resolves #465 by upgrading to a newly released non-beta gevent version.
