### PR TITLE
don't explode worker thread during interpreter shutdown

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -188,6 +188,8 @@ class RequestHandler(object):
                     task = shared.requests.get(timeout=1)
                 except Empty:
                     continue
+                except TypeError:  # can happen on interpreter shutdown
+                    break
                 try:
                     shared.connection.request(task.request)
                     if task.future:


### PR DESCRIPTION
This pull request catches the `Queue` exception that can occur if some requests are still in flight after interpreter shutdown. The nicer way to fix this would be to ensure that it never happens in the first place, but this handler is a good fallback whether or not we decide to do that.

Fixes #399