### PR TITLE
Add a callback parameter to produced messages, called upon receipt

### DIFF
--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -152,6 +152,7 @@ class Message(Message, Serializable):
     :ivar offset: The offset of the message
     :ivar partition_id: The id of the partition to which this message belongs
     :ivar delivery_report_q: For use by :class:`pykafka.producer.Producer`
+    :ivar callback: For use by :class:`pykafka.producer.Producer`
     """
     MAGIC = 0
 
@@ -163,7 +164,8 @@ class Message(Message, Serializable):
         "partition_id",
         "partition",
         "produce_attempt",
-        "delivery_report_q"
+        "delivery_report_q",
+        "callback"
     ]
 
     def __init__(self,
@@ -173,7 +175,8 @@ class Message(Message, Serializable):
                  offset=-1,
                  partition_id=-1,
                  produce_attempt=0,
-                 delivery_report_q=None):
+                 delivery_report_q=None,
+                 callback=None):
         self.compression_type = compression_type
         self.partition_key = partition_key
         self.value = value
@@ -186,6 +189,7 @@ class Message(Message, Serializable):
         self.produce_attempt = produce_attempt
         # delivery_report_q is used by the producer
         self.delivery_report_q = delivery_report_q
+        self.callback = callback
 
     def __len__(self):
         size = 4 + 1 + 1 + 4 + 4


### PR DESCRIPTION
Rather than iterate over a delivery report, an optional callback per message
is used that gets called when the message is marked as delivered. This
makes it easier to attach behaviors to particular messages without having to
correlate message bodies in a delivery report.

A sample use case is some kind of cleanup code that should only be run when a message has been guaranteed delivered. For example, a data / message bridge where messages can be dequeued (or acknowledged) from a master queue only when delivery is guaranteed in Kafka to avoid data loss. In my case, a rabbitMQ message broker is being replicated into Kafka. The message in Rabbit should only be ack'd when delivery is guaranteed otherwise there could be data loss.

This could be done by creating a registry of all sent messages and their cleanup code, then iterating over the delivery report and correlating the message with the registry, but that gets complicated and messy fast. This code uses the existing record of produced messages in pykafka (the message set / message_batch) and adds an optional callback to each message. When the delivery check is done, the callback attached to the message is executed if there is one. This keeps the async nature of the delivery check but allows attaching behaviors to the delivery check.