### PR TITLE
stop producer tests from sharing a consumer instance

### DIFF
--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -30,7 +30,6 @@ class ProducerIntegrationTests(unittest2.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.consumer.stop()
         stop_cluster(cls.kafka)
 
     def _get_producer(self, **kwargs):


### PR DESCRIPTION
Fixes #484