### PR TITLE
Handle AttributeError in daemon thread for interpreter shutdown

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -191,7 +191,7 @@ class RequestHandler(object):
                     task = shared.requests.get(timeout=1)
                 except Empty:
                     continue
-                except TypeError:  # can happen on interpreter shutdown
+                except (TypeError, AttributeError):  # can happen on interpreter shutdown
                     break
                 try:
                     shared.connection.request(task.request)


### PR DESCRIPTION
I see a recent commit https://github.com/Parsely/pykafka/commit/d2a7e4ca3a6ea85c72fd38b81f638888dd0c2393, which handles a TypeError caused by the messy nature of working with daemon threads. This is cool.

I am also seeing AttributeErrors with some frequency originating in the same spot when using Pykafka in a web application that is run multithreaded under Gunicorn:
```
Exception in thread 18: pykafka.RequestHandler.worker for broker-18.kafka.prclt.net:9092 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
 File "/usr/lib/python2.7/threading.py", line 551, in __bootstrap_inner
 File "/usr/lib/python2.7/threading.py", line 504, in run
 File "/usr/local/lib/python2.7/dist-packages/pykafka/handlers.py", line 206, in worker
<type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'info'
```
That's just a logging attempt after logging has been destroyed during interpreter shutdown. And

```
Unhandled exception in thread started by <bound method Thread.__bootstrap of <Thread(1: pykafka.RequestHandler.worker for broker-1.kafka.prclt.net:9092, stopped daemon 140024375449344)>>
Traceback (most recent call last):
 File "/usr/lib/python2.7/threading.py", line 524, in __bootstrap
 self.__bootstrap_inner()
 File "/usr/lib/python2.7/threading.py", line 564, in __bootstrap_inner
 (self.name, _format_exc()))
 File "/usr/lib/python2.7/traceback.py", line 240, in format_exc
 etype, value, tb = sys.exc_info()
AttributeError: 'NoneType' object has no attribute 'exc_info'
```

where, similarly, `sys` has already been destroyed.

It's not a critical bug as the Python process is already going down, but causes a ton of log noise, which obscures real problems and is a bummer.