### PR TITLE
Handle exceptions in intepreter shutdown in RequestHandler

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -26,6 +26,7 @@ import gevent.queue
 import gevent.socket as gsocket
 import logging
 import socket as pysocket
+import sys
 import threading
 import time
 
@@ -185,25 +186,32 @@ class RequestHandler(object):
         shared = self.shared
 
         def worker():
-            while not shared.ending.is_set():
-                try:
-                    # set a timeout so we check `ending` every so often
-                    task = shared.requests.get(timeout=1)
-                except Empty:
-                    continue
-                except TypeError:  # can happen on interpreter shutdown
-                    break
-                try:
-                    shared.connection.request(task.request)
-                    if task.future:
-                        res = shared.connection.response()
-                        task.future.set_response(res)
-                except Exception as e:
-                    if task.future:
-                        task.future.set_error(e)
-                finally:
-                    shared.requests.task_done()
-            log.info("RequestHandler worker: exiting cleanly")
+            try:
+                while not shared.ending.is_set():
+                    try:
+                        # set a timeout so we check `ending` every so often
+                        task = shared.requests.get(timeout=1)
+                    except Empty:
+                        continue
+                    try:
+                        shared.connection.request(task.request)
+                        if task.future:
+                            res = shared.connection.response()
+                            task.future.set_response(res)
+                    except Exception as e:
+                        if task.future:
+                            task.future.set_error(e)
+                    finally:
+                        shared.requests.task_done()
+                log.info("RequestHandler worker: exiting cleanly")
+            except:
+                # deal with interpreter shutdown in the same way that
+                # python 3.x's threading module does, swallowing any
+                # errors raised when core modules such as sys have
+                # already been destroyed
+                if sys is None:
+                    return
+                raise
 
         name = "pykafka.RequestHandler.worker for {}:{}".format(
             self.shared.connection.host, self.shared.connection.port)

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -26,7 +26,7 @@ import gevent.queue
 import gevent.socket as gsocket
 import logging
 import socket as pysocket
-import sys
+import sys as _sys
 import threading
 import time
 
@@ -209,7 +209,7 @@ class RequestHandler(object):
                 # python 3.x's threading module does, swallowing any
                 # errors raised when core modules such as sys have
                 # already been destroyed
-                if sys is None:
+                if _sys is None:
                     return
                 raise
 


### PR DESCRIPTION
Supersedes my weak attempt this AM at https://github.com/Parsely/pykafka/pull/521...

I am seeing assorted errors with some frequency originating in the handler function within RequestHandler._start_thread when using Pykafka in a web application that is run multithreaded under Gunicorn.

I see a recent commit d2a7e4c, which handles a TypeError caused by the messy nature of working with daemon threads. This is cool, but doesn't go quite far enough -- as the whole universe is getting deconstructed around the daemon thread, errors can originate in fairly hard-to-predict ways in this kind of context.

This patch uses an approach yanked from py3k's threading module -- just check to see if `sys` still exists before raising.

It's not a critical problem as the Python process is already going down, but causes a ton of log noise, which obscures real problems and is a bummer. Here are some of my errors from production:

```
Exception in thread 18: pykafka.RequestHandler.worker for broker-18.kafka.prclt.net:9092 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
 File "/usr/lib/python2.7/threading.py", line 551, in __bootstrap_inner
 File "/usr/lib/python2.7/threading.py", line 504, in run
 File "/usr/local/lib/python2.7/dist-packages/pykafka/handlers.py", line 206, in worker
<type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'info'
```

```
Unhandled exception in thread started by <bound method Thread.__bootstrap of <Thread(1: pykafka.RequestHandler.worker for broker-1.kafka.prclt.net:9092, stopped daemon 140024375449344)>>
Traceback (most recent call last):
 File "/usr/lib/python2.7/threading.py", line 524, in __bootstrap
 self.__bootstrap_inner()
 File "/usr/lib/python2.7/threading.py", line 564, in __bootstrap_inner
 (self.name, _format_exc()))
 File "/usr/lib/python2.7/traceback.py", line 240, in format_exc
 etype, value, tb = sys.exc_info()
AttributeError: 'NoneType' object has no attribute 'exc_info'
```