### PR TITLE
tests: fix test_recover_disconnected()

### DIFF
--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -98,7 +98,6 @@ class ProducerIntegrationTests(unittest2.TestCase):
         """Test our retry-loop with a recoverable error"""
         payload = uuid4().bytes
         prod = self._get_producer(min_queued_messages=1, delivery_reports=True)
-        consumer = self._get_consumer()
 
         for broker in self.client.brokers.values():
             broker._connection.disconnect()
@@ -106,9 +105,6 @@ class ProducerIntegrationTests(unittest2.TestCase):
         prod.produce(payload)
         report = prod.get_delivery_report()
         self.assertIsNone(report[1])
-
-        message = consumer.consume()
-        self.assertEqual(message.value, payload)
 
     def test_async_produce_context(self):
         """Ensure that the producer works as a context manager"""


### PR DESCRIPTION
This test was regularly failing recently.  It has been modified in #513,
which changed it to have both a running consumer and producer at the
point where the brokers are disconnected from.

The result is that it may be the consumer instead of the producer which
attempts connection recovery (problematic because this is the feature
under test), which probably explains the consumer timeouts (consume
calls returning None) observed in test runs.

This fix is the simplest solution, dropping the consume call completely.
