### PR TITLE
extra consumers

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -535,15 +535,7 @@ class BalancedConsumer(object):
         self._setting_watches = False
 
     def _add_self(self):
-        """Register this consumer in zookeeper.
-
-        This method ensures that the number of participants is at most the
-        number of partitions.
-        """
-        participants = self._get_participants()
-        if len(self._topic.partitions) <= len(participants):
-            raise KafkaException("Cannot add consumer: more consumers than partitions")
-
+        """Register this consumer in zookeeper."""
         self._zookeeper.create(
             self._path_self, self._topic.name, ephemeral=True, makepath=True)
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -227,9 +227,8 @@ class SimpleConsumer(object):
             raise ex
 
     def _update(self):
-        """Update the consumer and cluster after an ERROR_CODE
-        """
-        # only allow one thread to be updating the producer at a time
+        """Update the consumer and cluster after an ERROR_CODE"""
+        # only allow one thread to be updating the consumer at a time
         with self._update_lock:
             self._cluster.update()
             self._setup_partitions_by_leader()

--- a/pykafka/utils/error_handlers.py
+++ b/pykafka/utils/error_handlers.py
@@ -68,10 +68,9 @@ def build_parts_by_error(response, partitions_by_id):
     parts_by_error = defaultdict(list)
     for topic_name in response.topics.keys():
         for partition_id, pres in iteritems(response.topics[topic_name]):
-            owned_partition = None
             if partitions_by_id is not None and partition_id in partitions_by_id:
                 owned_partition = partitions_by_id[partition_id]
-            parts_by_error[pres.err].append((owned_partition, pres))
+                parts_by_error[pres.err].append((owned_partition, pres))
     return parts_by_error
 
 

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -213,11 +213,11 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
             self.wait_for_rebalancing(*consumers)
             verify_extras(consumers, extras)
         finally:
-            try:
-                for consumer in consumers:
+            for consumer in consumers:
+                try:
                     consumer.stop()
-            except:
-                pass
+                except:
+                    pass
 
     def test_rebalance_callbacks(self):
         def on_rebalance(cns, old_partition_offsets, new_partition_offsets):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -170,6 +170,42 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
             **kwargs
         )
 
+    def test_extra_consumer(self):
+        """Ensure proper operation of "extra" consumers in a group
+
+        An "extra" consumer is the N+1th member of a consumer group consuming a topic
+        of N partitions, and any consumer beyond the N+1th.
+        """
+        group = "test_extra_consumer"
+        extras = 1
+
+        def verify_extras(consumers, extras_count):
+            messages = [c.consume() for c in consumers]
+            nones = [a for a in messages if a is None]
+            successes = [a for a in messages if a is not None]
+            self.assertEqual(len(nones), extras_count)
+            self.assertEqual(len(successes), self.n_partitions)
+
+        consumers = [self.get_balanced_consumer(group,
+                                                consumer_timeout_ms=5000)
+                     for i in range(self.n_partitions + extras)]
+        verify_extras(consumers, extras)
+
+        # when one consumer stops, the extra should pick up its partitions
+        for i in range(extras):
+            removed = consumers[i]
+            removed.stop()
+            consumers = [a for a in consumers if a is not removed]
+        self.wait_for_rebalancing(*consumers)
+        self.assertEqual(len(consumers), self.n_partitions)
+        verify_extras(consumers, 0)
+
+        # added extra consumers should idle
+        for i in range(extras):
+            consumers.append(self.get_balanced_consumer(group, consumer_timeout_ms=5000))
+        self.wait_for_rebalancing(*consumers)
+        verify_extras(consumers, extras)
+
     def test_rebalance_callbacks(self):
         def on_rebalance(cns, old_partition_offsets, new_partition_offsets):
             self.assertTrue(len(new_partition_offsets) > 0)

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -176,7 +176,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         An "extra" consumer is the N+1th member of a consumer group consuming a topic
         of N partitions, and any consumer beyond the N+1th.
         """
-        group = "test_extra_consumer"
+        group = b"test_extra_consumer"
         extras = 1
 
         def verify_extras(consumers, extras_count):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -205,7 +205,7 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         self.assertEqual(len(consumers), self.n_partitions)
         verify_extras(consumers, 0)
 
-        # added extra consumers should idle
+        # added "extra" consumers should idle
         for i in range(extras):
             consumers.append(self.get_balanced_consumer(group, consumer_timeout_ms=5000))
         self.wait_for_rebalancing(*consumers)


### PR DESCRIPTION
This pull request fixes #527 by removing the upper limit on the number of consumers in a group. It also adds some tests to ensure that messages are not duplicated across a consumer group when there are more consumers than partitions.