### PR TITLE
raise thread exceptions from sync producer

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -330,6 +330,7 @@ class Producer(object):
 
         if self._synchronous:
             while True:
+                self._raise_worker_exceptions()
                 self._cluster.handler.sleep()
                 try:
                     reported_msg, exc = self.get_delivery_report(timeout=1)

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -3,6 +3,7 @@ from __future__ import division
 import platform
 import pytest
 import time
+import types
 import unittest2
 from uuid import uuid4
 
@@ -66,7 +67,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         p = self._get_producer(sync=True)
         def stub_send_request(self, message_batch, owned_broker):
             1/0
-        p._send_request = stub_send_request
+        p._send_request = types.MethodType(stub_send_request, p)
         with self.assertRaises(ZeroDivisionError):
             p.produce(b"test")
 

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -62,6 +62,14 @@ class ProducerIntegrationTests(unittest2.TestCase):
             with self.assertRaises(MessageSizeTooLarge):
                 prod.produce(10 ** 7 * b" ")
 
+        # ensure that a crash on a worker thread still raises in sync mode
+        p = self._get_producer(sync=True)
+        def stub_send_request(self, message_batch, owned_broker):
+            1/0
+        p._send_request = stub_send_request
+        with self.assertRaises(ZeroDivisionError):
+            p.produce(b"test")
+
     def test_produce_hashing_partitioner(self):
         # unique bytes, just to be absolutely sure we're not fetching data
         # produced in a previous test

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -64,7 +64,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
                 prod.produce(10 ** 7 * b" ")
 
         if not self.USE_RDKAFKA:
-            # ensure that a crash on a worker thread still raises in sync mode
+            # ensure that a crash on a worker thread still raises exception in sync mode
             p = self._get_producer(sync=True)
             def stub_send_request(self, message_batch, owned_broker):
                 1/0

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -63,13 +63,14 @@ class ProducerIntegrationTests(unittest2.TestCase):
             with self.assertRaises(MessageSizeTooLarge):
                 prod.produce(10 ** 7 * b" ")
 
-        # ensure that a crash on a worker thread still raises in sync mode
-        p = self._get_producer(sync=True)
-        def stub_send_request(self, message_batch, owned_broker):
-            1/0
-        p._send_request = types.MethodType(stub_send_request, p)
-        with self.assertRaises(ZeroDivisionError):
-            p.produce(b"test")
+        if not self.USE_RDKAFKA:
+            # ensure that a crash on a worker thread still raises in sync mode
+            p = self._get_producer(sync=True)
+            def stub_send_request(self, message_batch, owned_broker):
+                1/0
+            p._send_request = types.MethodType(stub_send_request, p)
+            with self.assertRaises(ZeroDivisionError):
+                p.produce(b"test")
 
     def test_produce_hashing_partitioner(self):
         # unique bytes, just to be absolutely sure we're not fetching data


### PR DESCRIPTION
This pull request fixes #558 by raising worker exceptions on every `produce()` loop iteration when `sync=True`. It also adds a regression test.