### PR TITLE
catch socket.error in connect()

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -161,12 +161,15 @@ class BrokerConnection(object):
     def connect(self, timeout):
         """Connect to the broker."""
         log.debug("Connecting to %s:%s", self.host, self.port)
-        self._socket = self._wrap_socket(
-            self._handler.Socket.create_connection(
-                (self.host, self.port),
-                timeout / 1000,
-                (self.source_host, self.source_port)
-            ))
+        try:
+            self._socket = self._wrap_socket(
+                self._handler.Socket.create_connection(
+                    (self.host, self.port),
+                    timeout / 1000,
+                    (self.source_host, self.source_port)
+                ))
+        except self._handler.SockErr:
+            log.error("Failed to connect to %s:%s", self.host, self.port)
         if self._socket is not None:
             log.debug("Successfully connected to %s:%s", self.host, self.port)
 

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -168,7 +168,7 @@ class BrokerConnection(object):
                     timeout / 1000,
                     (self.source_host, self.source_port)
                 ))
-        except self._handler.SockErr:
+        except (self._handler.SockErr, self._handler.GaiError):
             log.error("Failed to connect to %s:%s", self.host, self.port)
         if self._socket is not None:
             log.debug("Successfully connected to %s:%s", self.host, self.port)

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -24,10 +24,10 @@ import gevent.event
 import gevent.lock
 import gevent.queue
 import gevent.socket as gsocket
-import gevent.socket.error as gsocket_error
+from gevent.socket import error as gsocket_error
 import logging
 import socket as pysocket
-import socket.error as socket_error
+from socket import error as socket_error
 import sys as _sys
 import threading
 import time

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -25,9 +25,11 @@ import gevent.lock
 import gevent.queue
 import gevent.socket as gsocket
 from gevent.socket import error as gsocket_error
+from gevent.socket import gaierror as g_gaierror
 import logging
 import socket as pysocket
 from socket import error as socket_error
+from socket import gaierror as gaierror
 import sys as _sys
 import threading
 import time
@@ -87,6 +89,7 @@ class ThreadingHandler(Handler):
     Semaphore = Semaphore
     Socket = pysocket
     SockErr = socket_error
+    GaiError = gaierror
     _workers_spawned = 0
 
     def sleep(self, seconds=0):
@@ -120,6 +123,7 @@ class GEventHandler(Handler):
     Semaphore = gevent.lock.Semaphore
     Socket = gsocket
     SockErr = gsocket_error
+    GaiError = g_gaierror
 
     def sleep(self, seconds=0):
         gevent.sleep(seconds)

--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -24,8 +24,10 @@ import gevent.event
 import gevent.lock
 import gevent.queue
 import gevent.socket as gsocket
+import gevent.socket.error as gsocket_error
 import logging
 import socket as pysocket
+import socket.error as socket_error
 import sys as _sys
 import threading
 import time
@@ -84,6 +86,7 @@ class ThreadingHandler(Handler):
     Lock = threading.Lock
     Semaphore = Semaphore
     Socket = pysocket
+    SockErr = socket_error
     _workers_spawned = 0
 
     def sleep(self, seconds=0):
@@ -116,6 +119,7 @@ class GEventHandler(Handler):
     RLock = gevent.lock.RLock
     Semaphore = gevent.lock.Semaphore
     Socket = gsocket
+    SockErr = gsocket_error
 
     def sleep(self, seconds=0):
         gevent.sleep(seconds)


### PR DESCRIPTION
This error can occur when a broker goes down between the metadata request and the broker connection attempt.

Related to #543

Fixes tracebacks that look like [this](https://github.com/Parsely/pykafka/issues/543#issuecomment-219058978)

cc @ottomata 