### PR TITLE
zk consumer group bytes literal

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -257,7 +257,7 @@ class BalancedConsumer(object):
             module=self.__class__.__module__,
             name=self.__class__.__name__,
             id_=hex(id(self)),
-            group=self._consumer_group
+            group=get_string(self._consumer_group)
         )
 
     def _raise_worker_exceptions(self):

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -235,10 +235,10 @@ class BalancedConsumer(object):
         self._setting_watches = True
 
         self._topic_path = '/consumers/{group}/owners/{topic}'.format(
-            group=self._consumer_group,
+            group=get_string(self._consumer_group),
             topic=self._topic.name)
         self._consumer_id_path = '/consumers/{group}/ids'.format(
-            group=self._consumer_group)
+            group=get_string(self._consumer_group))
 
         self._zookeeper = None
         self._owns_zookeeper = zookeeper is None


### PR DESCRIPTION
This pull request fixes #567 by converting consumer group names to strings before storing them in zookeeper.