### PR TITLE
fix timeouts when rebalancing with consumer_timeout_ms

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -348,6 +348,9 @@ class SimpleConsumer(object):
         self._running = False
         if self._auto_commit_enable and self._consumer_group is not None:
             self.commit_offsets()
+        # unblock a waiting consume() call
+        if self._messages_arrived is not None:
+            self._messages_arrived.release()
 
     def _setup_autocommit_worker(self):
         """Start the autocommitter thread"""


### PR DESCRIPTION
Fixes #528. See explanation [here](https://github.com/Parsely/pykafka/issues/528#issuecomment-231174125). Testing this fix requires starting a rebalance while a `consume()` call is pending, which requires the use of threads in integration tests, which I'd like to stay away from for now. It's had some negative effects on our Travis builds in the past.