### PR TITLE
Type hinting: hostnames are strings, not bytes

### DIFF
--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -56,10 +56,10 @@ class KafkaClient(object):
         :param hosts: Comma-separated list of kafka hosts to which to connect.
             If `ssl_config` is specified, the ports specified here are assumed
             to be SSL ports
-        :type hosts: bytes
+        :type hosts: str
         :param zookeeper_hosts: KazooClient-formatted string of ZooKeeper hosts to which
             to connect. If not `None`, this argument takes precedence over `hosts`
-        :type zookeeper_hosts: bytes
+        :type zookeeper_hosts: str
         :param socket_timeout_ms: The socket timeout (in milliseconds) for
             network requests
         :type socket_timeout_ms: int

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -161,10 +161,10 @@ class Cluster(object):
         """Create a new Cluster instance.
 
         :param hosts: Comma-separated list of kafka hosts to which to connect.
-        :type hosts: bytes
+        :type hosts: str
         :param zookeeper_hosts: KazooClient-formatted string of ZooKeeper hosts to which
             to connect. If not `None`, this argument takes precedence over `hosts`
-        :type zookeeper_hosts: bytes
+        :type zookeeper_hosts: str
         :param handler: The concurrency handler for network requests.
         :type handler: :class:`pykafka.handlers.Handler`
         :param socket_timeout_ms: The socket timeout (in milliseconds) for


### PR DESCRIPTION
These type hints say that hosts and zookeeper_hosts should be bytes, but they are actually strings.