### PR TITLE
include consumer id and hostname in offset metadata

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -31,7 +31,7 @@ import weakref
 
 from .common import OffsetType
 from .utils.compat import (Queue, Empty, iteritems, itervalues,
-                           range, iterkeys, get_bytes)
+                           range, iterkeys, get_bytes, get_string)
 from .exceptions import (UnknownError, OffsetOutOfRangeError, UnknownTopicOrPartition,
                          OffsetMetadataTooLarge, GroupLoadInProgress,
                          NotCoordinatorForGroup, SocketDisconnectedError,
@@ -799,7 +799,7 @@ class OwnedPartition(object):
         self.fetch_lock = handler.RLock() if handler is not None else threading.RLock()
         # include consumer id in offset metadata for debugging
         self._offset_metadata = {
-            'consumer_id': self._consumer_id,
+            'consumer_id': get_string(self._consumer_id),
             'hostname': socket.gethostname()
         }
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -802,6 +802,8 @@ class OwnedPartition(object):
             'consumer_id': get_string(self._consumer_id),
             'hostname': socket.gethostname()
         }
+        # precalculate json to avoid expensive operation in loops
+        self._offset_metadata_json = json.dumps(self._offset_metadata)
 
     @property
     def message_count(self):
@@ -868,7 +870,7 @@ class OwnedPartition(object):
             self.partition.id,
             self.last_offset_consumed + 1,
             int(time.time() * 1000),
-            get_bytes('{}'.format(json.dumps(self._offset_metadata)))
+            get_bytes('{}'.format(self._offset_metadata_json))
         )
 
     def build_offset_fetch_request(self):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -189,17 +189,19 @@ class SimpleConsumer(object):
         self._discover_group_coordinator()
 
         if partitions is not None:
-            self._partitions = {p: OwnedPartition(p, self._consumer_id,
+            self._partitions = {p: OwnedPartition(p,
                                                   self._cluster.handler,
                                                   self._messages_arrived,
-                                                  self._is_compacted_topic)
+                                                  self._is_compacted_topic,
+                                                  self._consumer_id)
                                 for p in partitions}
         else:
             self._partitions = {topic.partitions[k]:
-                                OwnedPartition(p, self._consumer_id,
+                                OwnedPartition(p,
                                                self._cluster.handler,
                                                self._messages_arrived,
-                                               self._is_compacted_topic)
+                                               self._is_compacted_topic,
+                                               self._consumer_id)
                                 for k, p in iteritems(topic.partitions)}
         self._partitions_by_id = {p.partition.id: p
                                   for p in itervalues(self._partitions)}
@@ -767,10 +769,10 @@ class OwnedPartition(object):
 
     def __init__(self,
                  partition,
-                 consumer_id=b'',
                  handler=None,
                  semaphore=None,
-                 compacted_topic=False):
+                 compacted_topic=False,
+                 consumer_id=b''):
         """
         :param partition: The partition to hold
         :type partition: :class:`pykafka.partition.Partition`

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -767,7 +767,7 @@ class OwnedPartition(object):
 
     def __init__(self,
                  partition,
-                 consumer_id,
+                 consumer_id=b'',
                  handler=None,
                  semaphore=None,
                  compacted_topic=False):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -31,7 +31,7 @@ import weakref
 
 from .common import OffsetType
 from .utils.compat import (Queue, Empty, iteritems, itervalues,
-                           range, iterkeys)
+                           range, iterkeys, get_bytes)
 from .exceptions import (UnknownError, OffsetOutOfRangeError, UnknownTopicOrPartition,
                          OffsetMetadataTooLarge, GroupLoadInProgress,
                          NotCoordinatorForGroup, SocketDisconnectedError,
@@ -868,7 +868,7 @@ class OwnedPartition(object):
             self.partition.id,
             self.last_offset_consumed + 1,
             int(time.time() * 1000),
-            b'{}'.format(json.dumps(self._offset_metadata))
+            get_bytes('{}'.format(json.dumps(self._offset_metadata)))
         )
 
     def build_offset_fetch_request(self):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -795,6 +795,7 @@ class OwnedPartition(object):
         self.last_offset_consumed = -1
         self.next_offset = 0
         self.fetch_lock = handler.RLock() if handler is not None else threading.RLock()
+        # include consumer id in offset metadata for debugging
         self._offset_metadata = {
             'consumer_id': self._consumer_id,
             'hostname': socket.gethostname()

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -20,6 +20,8 @@ limitations under the License.
 __all__ = ["SimpleConsumer"]
 import itertools
 import logging
+import json
+import socket
 import sys
 import threading
 import time
@@ -187,13 +189,15 @@ class SimpleConsumer(object):
         self._discover_group_coordinator()
 
         if partitions is not None:
-            self._partitions = {p: OwnedPartition(p, self._cluster.handler,
+            self._partitions = {p: OwnedPartition(p, self._consumer_id,
+                                                  self._cluster.handler,
                                                   self._messages_arrived,
                                                   self._is_compacted_topic)
                                 for p in partitions}
         else:
             self._partitions = {topic.partitions[k]:
-                                OwnedPartition(p, self._cluster.handler,
+                                OwnedPartition(p, self._consumer_id,
+                                               self._cluster.handler,
                                                self._messages_arrived,
                                                self._is_compacted_topic)
                                 for k, p in iteritems(topic.partitions)}
@@ -761,10 +765,17 @@ class OwnedPartition(object):
     Used to keep track of offsets and the internal message queue.
     """
 
-    def __init__(self, partition, handler=None, semaphore=None, compacted_topic=False):
+    def __init__(self,
+                 partition,
+                 consumer_id,
+                 handler=None,
+                 semaphore=None,
+                 compacted_topic=False):
         """
         :param partition: The partition to hold
         :type partition: :class:`pykafka.partition.Partition`
+        :param consumer_id: The ID of the parent consumer
+        :type consumer_id: bytes
         :param handler: The :class:`pykafka.handlers.Handler` instance to use
             to generate a lock
         type handler: :class:`pykafka.handler.Handler`
@@ -777,12 +788,17 @@ class OwnedPartition(object):
         :type compacted_topic: bool
         """
         self.partition = partition
+        self._consumer_id = consumer_id
         self._messages = Queue()
         self._messages_arrived = semaphore
         self._is_compacted_topic = compacted_topic
         self.last_offset_consumed = -1
         self.next_offset = 0
         self.fetch_lock = handler.RLock() if handler is not None else threading.RLock()
+        self._offset_metadata = {
+            'consumer_id': self._consumer_id,
+            'hostname': socket.gethostname()
+        }
 
     @property
     def message_count(self):
@@ -849,7 +865,7 @@ class OwnedPartition(object):
             self.partition.id,
             self.last_offset_consumed + 1,
             int(time.time() * 1000),
-            b'pykafka'
+            b'{}'.format(json.dumps(self._offset_metadata))
         )
 
     def build_offset_fetch_request(self):

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -293,7 +293,7 @@ class TestOwnedPartition(unittest2.TestCase):
         self.assertEqual(request.partition_id, partition.id)
         self.assertEqual(request.offset, op.last_offset_consumed + 1)
         parsed_metadata = json.loads(get_string(request.metadata))
-        self.assertEqual(parsed_metadata["consumer_id"], b'')
+        self.assertEqual(parsed_metadata["consumer_id"], '')
         self.assertTrue(bool(parsed_metadata["hostname"]))
 
     def test_partition_offset_fetch_request(self):

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import json
 import mock
 import platform
 import pytest
@@ -289,7 +290,9 @@ class TestOwnedPartition(unittest2.TestCase):
         self.assertEqual(request.topic_name, topic.name)
         self.assertEqual(request.partition_id, partition.id)
         self.assertEqual(request.offset, op.last_offset_consumed + 1)
-        self.assertEqual(request.metadata, b'pykafka')
+        parsed_metadata = json.loads(request.metadata)
+        self.assertEqual(parsed_metadata["consumer_id"], b'')
+        self.assertTrue(bool(parsed_metadata["hostname"]))
 
     def test_partition_offset_fetch_request(self):
         topic = mock.Mock()

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from pykafka import KafkaClient
 from pykafka.simpleconsumer import OwnedPartition, OffsetType
 from pykafka.test.utils import get_cluster, stop_cluster
-from pykafka.utils.compat import range, iteritems
+from pykafka.utils.compat import range, iteritems, get_string
 
 
 kafka_version = os.environ.get('KAFKA_VERSION', '0.8.0')
@@ -292,7 +292,7 @@ class TestOwnedPartition(unittest2.TestCase):
         self.assertEqual(request.topic_name, topic.name)
         self.assertEqual(request.partition_id, partition.id)
         self.assertEqual(request.offset, op.last_offset_consumed + 1)
-        parsed_metadata = json.loads(request.metadata)
+        parsed_metadata = json.loads(get_string(request.metadata))
         self.assertEqual(parsed_metadata["consumer_id"], b'')
         self.assertTrue(bool(parsed_metadata["hostname"]))
 


### PR DESCRIPTION
This pull request adds a bit of useful information to the offset metadata field in offset commit requests. The consumer ID can be useful when debugging certain failure modes, as we've seen at Parsely. Comments welcome if there is any other information it might make sense to include here.

@dan-blanchard, if consumers were running this code, you'd be able to see consumer IDs and hostnames in our lag monitor.