### PR TITLE
Pass protocol version to librdkafka

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ install:
         fi
     - pip install -U pip setuptools
     - pip install codecov kazoo tox testinstances tox-travis "gevent==1.1"
-    - wget https://github.com/edenhill/librdkafka/archive/0.9.0.99.tar.gz
-    - tar -xzf 0.9.0.99.tar.gz
-    - cd librdkafka-0.9.0.99/ && ./configure --prefix=$HOME
+    - wget https://github.com/edenhill/librdkafka/archive/0.9.1.tar.gz
+    - tar -xzf 0.9.1.tar.gz
+    - cd librdkafka-0.9.1/ && ./configure --prefix=$HOME
     - make -j 2 && make -j 2 install && cd -
 
 before_script:
@@ -64,7 +64,7 @@ before_script:
     - export `grep ZOOKEEPER $TEMPFILE`
 
 script:
-    - tox
+    - tox tests
 
 # Calculate coverage on success
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -163,11 +163,11 @@ After that, all that's needed is that you pass an extra parameter
 that some configuration options may have different optimal values; it may be
 worthwhile to consult librdkafka's `configuration notes`_ for this.
 
-We currently test against librdkafka `0.9.0.99`_ only.  Note that use on pypy is
+We currently test against librdkafka `0.9.1`_ only.  Note that use on pypy is
 not recommended at this time; the producer is certainly expected to crash.
 
-.. _0.9.0.99: https://github.com/edenhill/librdkafka/releases/tag/0.9.0.99
-.. _configuration notes: https://github.com/edenhill/librdkafka/blob/0.9.0.99/CONFIGURATION.md
+.. _0.9.1: https://github.com/edenhill/librdkafka/releases/tag/0.9.1
+.. _configuration notes: https://github.com/edenhill/librdkafka/blob/0.9.1/CONFIGURATION.md
 
 Operational Tools
 -----------------

--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -48,7 +48,7 @@ class KafkaClient(object):
                  exclude_internal_topics=True,
                  source_address='',
                  ssl_config=None,
-                 broker_version=b'0.9.0'):
+                 broker_version='0.9.0'):
         """Create a connection to a Kafka cluster.
 
         Documentation for source_address can be found at
@@ -81,7 +81,7 @@ class KafkaClient(object):
         :param broker_version: The protocol version of the cluster being connected to.
             If this parameter doesn't match the actual broker version, some pykafka
             features may not work properly.
-        :type broker_version: bytes
+        :type broker_version: str
         """
         self._seed_hosts = zookeeper_hosts if zookeeper_hosts is not None else hosts
         self._source_address = source_address

--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -47,7 +47,8 @@ class KafkaClient(object):
                  use_greenlets=False,
                  exclude_internal_topics=True,
                  source_address='',
-                 ssl_config=None):
+                 ssl_config=None,
+                 broker_version=b'0.9.0'):
         """Create a connection to a Kafka cluster.
 
         Documentation for source_address can be found at
@@ -77,6 +78,10 @@ class KafkaClient(object):
         :type source_address: str `'host:port'`
         :param ssl_config: Config object for SSL connection
         :type ssl_config: :class:`pykafka.connection.SslConfig`
+        :param broker_version: The protocol version of the cluster being connected to.
+            If this parameter doesn't match the actual broker version, some pykafka
+            features may not work properly.
+        :type broker_version: bytes
         """
         self._seed_hosts = zookeeper_hosts if zookeeper_hosts is not None else hosts
         self._source_address = source_address
@@ -91,7 +96,8 @@ class KafkaClient(object):
             exclude_internal_topics=exclude_internal_topics,
             source_address=self._source_address,
             zookeeper_hosts=zookeeper_hosts,
-            ssl_config=ssl_config)
+            ssl_config=ssl_config,
+            broker_version=broker_version)
         self.brokers = self.cluster.brokers
         self.topics = self.cluster.topics
 

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -158,7 +158,7 @@ class Cluster(object):
                  source_address='',
                  zookeeper_hosts=None,
                  ssl_config=None,
-                 broker_version=b'0.9.0'):
+                 broker_version='0.9.0'):
         """Create a new Cluster instance.
 
         :param hosts: Comma-separated list of kafka hosts to which to connect.
@@ -185,7 +185,7 @@ class Cluster(object):
         :param broker_version: The protocol version of the cluster being connected to.
             If this parameter doesn't match the actual broker version, some pykafka
             features may not work properly.
-        :type broker_version: bytes
+        :type broker_version: str
         """
         self._seed_hosts = zookeeper_hosts if zookeeper_hosts is not None else hosts
         self._socket_timeout_ms = socket_timeout_ms

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -157,7 +157,8 @@ class Cluster(object):
                  exclude_internal_topics=True,
                  source_address='',
                  zookeeper_hosts=None,
-                 ssl_config=None):
+                 ssl_config=None,
+                 broker_version=b'0.9.0'):
         """Create a new Cluster instance.
 
         :param hosts: Comma-separated list of kafka hosts to which to connect.
@@ -181,6 +182,10 @@ class Cluster(object):
         :type source_address: str `'host:port'`
         :param ssl_config: Config object for SSL connection
         :type ssl_config: :class:`pykafka.connection.SslConfig`
+        :param broker_version: The protocol version of the cluster being connected to.
+            If this parameter doesn't match the actual broker version, some pykafka
+            features may not work properly.
+        :type broker_version: bytes
         """
         self._seed_hosts = zookeeper_hosts if zookeeper_hosts is not None else hosts
         self._socket_timeout_ms = socket_timeout_ms
@@ -194,6 +199,7 @@ class Cluster(object):
         self._ssl_config = ssl_config
         self._zookeeper_connect = zookeeper_hosts
         self._max_connection_retries = 3
+        self._broker_version = broker_version
         if ':' in self._source_address:
             self._source_port = int(self._source_address.split(':')[1])
         self.update()

--- a/pykafka/rdkafka/producer.py
+++ b/pykafka/rdkafka/producer.py
@@ -22,6 +22,9 @@ class RdKafkaProducer(Producer):
     implementation, `retry_backoff_ms` indicates the exact time spent between message
     resend attempts, but in the pure Python version the time between attempts is also
     influenced by several other parameters, including `linger_ms` and `socket_timeout_ms`.
+
+    The `broker_version` argument on `KafkaClient` must be set correctly to use the
+    rdkafka producer.
     """
     def __init__(self,
                  cluster,

--- a/pykafka/rdkafka/producer.py
+++ b/pykafka/rdkafka/producer.py
@@ -41,6 +41,7 @@ class RdKafkaProducer(Producer):
                  auto_start=True):
         callargs = {k: v for k, v in vars().items()
                     if k not in ("self", "__class__")}
+        self._broker_version = cluster._broker_version
         self._rdk_producer = None
         self._poller_thread = None
         self._stop_poller_thread = cluster.handler.Event()
@@ -100,6 +101,7 @@ class RdKafkaProducer(Producer):
 
         conf = {  # destination: rd_kafka_conf_set
             "client.id": "pykafka.rdkafka",
+            "broker.version.fallback": self._broker_version,
             # Handled via rd_kafka_brokers_add instead:
             # "metadata.broker.list"
 

--- a/pykafka/rdkafka/simple_consumer.py
+++ b/pykafka/rdkafka/simple_consumer.py
@@ -27,6 +27,9 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
 
     For an overview of how configuration keys are mapped to librdkafka's, see
     _mk_rdkafka_config_lists.
+
+    The `broker_version` argument on `KafkaClient` must be set correctly to use the
+    rdkafka consumer.
     """
     def __init__(self,
                  topic,

--- a/pykafka/rdkafka/simple_consumer.py
+++ b/pykafka/rdkafka/simple_consumer.py
@@ -54,6 +54,7 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
         self._rdk_consumer = None
         self._poller_thread = None
         self._stop_poller_thread = cluster.handler.Event()
+        self._broker_version = cluster._broker_version
         # super() must come last for the case where auto_start=True
         super(RdKafkaSimpleConsumer, self).__init__(**callargs)
 
@@ -185,6 +186,7 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
 
         conf = {  # destination: rd_kafka_conf_set
             "client.id": "pykafka.rdkafka",
+            "broker.version.fallback": self._broker_version,
             # Handled via rd_kafka_brokers_add instead:
             ##"metadata.broker.list"
 

--- a/tests/pykafka/rdkafka/test_rd_kafka_consumer.py
+++ b/tests/pykafka/rdkafka/test_rd_kafka_consumer.py
@@ -1,5 +1,8 @@
 from contextlib import contextmanager
+import platform
 import unittest2
+
+import pytest
 
 from pykafka.exceptions import RdKafkaStoppedException, RdKafkaException
 from pykafka.rdkafka import _rd_kafka
@@ -7,6 +10,9 @@ from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import get_bytes
 
 
+@pytest.mark.skipif(platform.python_implementation() == "PyPy",
+                    reason="Unresolved crashes which I cannot reproduce "
+                           "locally (TODO: track this down).")
 class TestRdKafkaConsumer(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -20,7 +20,8 @@ from pykafka.utils.compat import range, iterkeys, iteritems
 from tests.pykafka import patch_subclass
 
 
-kafka_version = pkg_resources.parse_version(os.environ.get('KAFKA_VERSION', '0.8'))
+kafka_version_string = os.environ.get('KAFKA_VERSION', '0.8')
+kafka_version = pkg_resources.parse_version(kafka_version_string)
 version_09 = pkg_resources.parse_version("0.9.0.0")
 
 
@@ -144,7 +145,9 @@ class BalancedConsumerIntegrationTests(unittest2.TestCase):
         cls.topic_name = uuid4().hex.encode()
         cls.n_partitions = 3
         cls.kafka.create_topic(cls.topic_name, cls.n_partitions, 2)
-        cls.client = KafkaClient(cls.kafka.brokers, use_greenlets=cls.USE_GEVENT)
+        cls.client = KafkaClient(cls.kafka.brokers,
+                                 use_greenlets=cls.USE_GEVENT,
+                                 broker_version=kafka_version_string)
         cls.prod = cls.client.topics[cls.topic_name].get_producer(
             min_queued_messages=1
         )

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import os
 import platform
 import pytest
 import time
@@ -17,6 +18,9 @@ from pykafka.common import CompressionType
 from pykafka.producer import OwnedBroker
 
 
+kafka_version = os.environ.get('KAFKA_VERSION', '0.8.0')
+
+
 class ProducerIntegrationTests(unittest2.TestCase):
     maxDiff = None
     USE_RDKAFKA = False
@@ -27,7 +31,9 @@ class ProducerIntegrationTests(unittest2.TestCase):
         cls.kafka = get_cluster()
         cls.topic_name = b'test-data'
         cls.kafka.create_topic(cls.topic_name, 3, 2)
-        cls.client = KafkaClient(cls.kafka.brokers, use_greenlets=cls.USE_GEVENT)
+        cls.client = KafkaClient(cls.kafka.brokers,
+                                 use_greenlets=cls.USE_GEVENT,
+                                 broker_version=kafka_version)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import mock
+import os
 import platform
 import pytest
 import time
@@ -10,6 +11,9 @@ from pykafka import KafkaClient
 from pykafka.simpleconsumer import OwnedPartition, OffsetType
 from pykafka.test.utils import get_cluster, stop_cluster
 from pykafka.utils.compat import range, iteritems
+
+
+kafka_version = os.environ.get('KAFKA_VERSION', '0.8.0')
 
 
 class TestSimpleConsumer(unittest2.TestCase):
@@ -24,7 +28,7 @@ class TestSimpleConsumer(unittest2.TestCase):
         cls.kafka.create_topic(cls.topic_name, 3, 2)
 
         cls.total_msgs = 1000
-        cls.client = KafkaClient(cls.kafka.brokers)
+        cls.client = KafkaClient(cls.kafka.brokers, broker_version=kafka_version)
         cls.prod = cls.client.topics[cls.topic_name].get_producer(
             min_queued_messages=1
         )

--- a/tests/pykafka/test_simpleconsumer.py
+++ b/tests/pykafka/test_simpleconsumer.py
@@ -35,8 +35,6 @@ class TestSimpleConsumer(unittest2.TestCase):
         for i in range(cls.total_msgs):
             cls.prod.produce('msg {i}'.format(i=i).encode())
 
-        cls.client = KafkaClient(cls.kafka.brokers)
-
     @classmethod
     def tearDownClass(cls):
         stop_cluster(cls.kafka)


### PR DESCRIPTION
This pull request adds to #573 support for the protocol fallback version in librdkafka. The commit list here is a bit screwy because branch `thedrow:patch-3` isn't up to date with master, and this branch is based on that one. Still, the diff is correct, and this should fix support for librdkafka 0.9.1.

cc @edenhill @thedrow 