### PR TITLE
flush() race condition

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -233,6 +233,9 @@ class Producer(object):
         """
         # only allow one thread to be updating the producer at a time
         with self._update_lock:
+            if self._owned_brokers is not None:
+                for owned_broker in list(self._owned_brokers.values()):
+                    owned_broker.stop()
             self._cluster.update()
             queued_messages = self._setup_owned_brokers()
             if len(queued_messages):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -592,6 +592,8 @@ class OwnedBroker(object):
             batch = []
             batch_size_in_bytes = 0
             while len(self.queue) > 0:
+                if not self.running:
+                    return []
                 peeked_message = self.queue[-1]
 
                 if peeked_message and peeked_message.value is not None:
@@ -629,6 +631,8 @@ class OwnedBroker(object):
                 self.increment_messages_pending(-1 * len(batch))
             if not self.slot_available.is_set():
                 self.slot_available.set()
+        if not self.running:
+            return []
         return batch
 
     def _wait_for_flush_ready(self, linger_ms):

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -372,12 +372,13 @@ class Producer(object):
         """
         success = False
         while not success:
-            leader_id = self._topic.partitions[message.partition_id].leader.id
-            if leader_id in self._owned_brokers:
-                self._owned_brokers[leader_id].enqueue(message)
-                success = True
-            else:
-                success = False
+            with self._update_lock:
+                leader_id = self._topic.partitions[message.partition_id].leader.id
+                if leader_id in self._owned_brokers:
+                    self._owned_brokers[leader_id].enqueue(message)
+                    success = True
+                else:
+                    success = False
 
     def _send_request(self, message_batch, owned_broker):
         """Send the produce request to the broker and handle the response.


### PR DESCRIPTION
This pull request fixes a bug caused by a race condition between a worker thread that is in the middle of an `_update()` call and one that is in the middle of a `flush()` call.

We `stop()` the `OwnedBroker`s before calling `_update` to ensure that no new `flush()` calls are initiated during the update. We also add logic to `flush()` to make any in-progress calls bail out as soon as possible upon `stop()`. These changes ensure that we don't get into a situation where the cluster has been updated and one of the worker threads that has not yet been stopped is calling `flush()` with outdated messages in its queue.

We also ensure that new messages cannot be enqueued during `update()` to avoid a similar condition. This does mean that `update()` calls will block `produce()` calls on the main thread. (I'd love an opinion from @kbourgoin on this point, especially about whether there might be a way around this behavior).

This branch reproducibly fixes an issue causing the producer to go into an infinite loop of `_update()` calls after a Kafka leader swap.