### PR TITLE
Fix 'raise StopIteration' in generator (PEP 479)

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -744,7 +744,7 @@ class BalancedConsumer(object):
         while True:
             message = self.consume(block=True)
             if not message:
-                raise StopIteration
+                return
             yield message
 
     def commit_offsets(self):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -409,7 +409,7 @@ class SimpleConsumer(object):
         while True:
             message = self.consume(block=True)
             if not message:
-                raise StopIteration
+                return
             yield message
 
     def consume(self, block=True):


### PR DESCRIPTION
This is a simple change to prevent `PendingDeprecationWarning`s on Python 3.5.  There is no change in semantics with any supported interpreter.