### PR TITLE
Populate common.Message.offset field when producer gets ack from broker

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -430,7 +430,10 @@ class Producer(object):
             for topic, partitions in iteritems(response.topics):
                 for partition, presponse in iteritems(partitions):
                     if presponse.err == 0:
-                        mark_as_delivered(req.msets[topic][partition].messages)
+                        messages = req.msets[topic][partition].messages
+                        for i, message in enumerate(messages):
+                            message.offset = presponse.offset + i
+                        mark_as_delivered(messages)
                         continue  # All's well
                     if presponse.err == NotLeaderForPartition.ERROR_CODE:
                         # Update cluster metadata to get new leader


### PR DESCRIPTION
Hello!

In my use case I need to get synchronously produce messages to kafka. It can be done by setting up `Producer` in `sync` mode which is ok.

Also I need to get offset of every message I send to kafka (or last message send to particular partition) hence I can't use `sync` mode because then delivery report for message get taken from queue before anything can be done about it. Simple solution is to wait for delivery report myself then get offset from `reported_msg` object. But `offet` field is aways emty. Kafka broker returns offset of last message in batch when it sends ack back but this information is never set on `Message` object.

Other solution is use `fetch_offset_limit` after each message but this is unnecessary roundtrip for data that is sent back anyway.