### PR TITLE
support 0.10's administrative API

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -28,7 +28,7 @@ from .protocol import (
     MetadataResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetFetchRequest,
     OffsetFetchResponse, ProduceResponse, JoinGroupRequest, JoinGroupResponse,
     SyncGroupRequest, SyncGroupResponse, HeartbeatRequest, HeartbeatResponse,
-    LeaveGroupRequest, LeaveGroupResponse)
+    LeaveGroupRequest, LeaveGroupResponse, ListGroupsRequest, ListGroupsResponse)
 from .utils.compat import range, iteritems, get_bytes
 
 log = logging.getLogger(__name__)
@@ -466,3 +466,11 @@ class Broker(object):
             HeartbeatRequest(consumer_group, generation_id, member_id))
         self._handler.sleep()
         return future.get(HeartbeatResponse)
+
+    ########################
+    #  Administrative API  #
+    ########################
+    def list_groups(self):
+        """Send a ListGroupsRequest"""
+        future = self._req_handler.request(ListGroupsRequest())
+        return future.get(ListGroupsResponse)

--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -28,7 +28,8 @@ from .protocol import (
     MetadataResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetFetchRequest,
     OffsetFetchResponse, ProduceResponse, JoinGroupRequest, JoinGroupResponse,
     SyncGroupRequest, SyncGroupResponse, HeartbeatRequest, HeartbeatResponse,
-    LeaveGroupRequest, LeaveGroupResponse, ListGroupsRequest, ListGroupsResponse)
+    LeaveGroupRequest, LeaveGroupResponse, ListGroupsRequest, ListGroupsResponse,
+    DescribeGroupsRequest, DescribeGroupsResponse)
 from .utils.compat import range, iteritems, get_bytes
 
 log = logging.getLogger(__name__)
@@ -474,3 +475,12 @@ class Broker(object):
         """Send a ListGroupsRequest"""
         future = self._req_handler.request(ListGroupsRequest())
         return future.get(ListGroupsResponse)
+
+    def describe_groups(self, group_ids):
+        """Send a DescribeGroupsRequest
+
+        :param group_ids: A sequence of group identifiers for which to return descriptions
+        :type group_ids: sequence of str
+        """
+        future = self._req_handler.request(DescribeGroupsRequest(group_ids))
+        return future.get(DescribeGroupsResponse)

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -379,9 +379,8 @@ class Cluster(object):
         """
         descriptions = {}
         for broker in itervalues(self.brokers):
-            res = broker.list_groups()
             res = broker.describe_groups([group.group_id for group
-                                          in itervalues(res.groups)])
+                                          in itervalues(broker.list_groups().groups)])
             descriptions.update(res.groups)
         return descriptions
 

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -371,6 +371,20 @@ class Cluster(object):
                 #       needed.
                 raise Exception('Broker host/port change detected! %s', broker)
 
+    def get_group_descriptions(self):
+        """Return detailed descriptions of all managed consumer groups on this cluster
+
+        This function only returns descriptions for consumer groups created via the
+        Group Management API, which pykafka refers to as :class:`ManagedBalancedConsumer`s
+        """
+        descriptions = {}
+        for broker in itervalues(self.brokers):
+            res = broker.list_groups()
+            res = broker.describe_groups([group.group_id for group
+                                          in itervalues(res.groups)])
+            descriptions.update(res.groups)
+        return descriptions
+
     def get_offset_manager(self, consumer_group):
         log.warning("WARNING: Cluster.get_offset_manager is deprecated since pykafka "
                     "2.3.0. Instead, use Cluster.get_group_coordinator.")

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -371,7 +371,7 @@ class Cluster(object):
                 #       needed.
                 raise Exception('Broker host/port change detected! %s', broker)
 
-    def get_group_descriptions(self):
+    def get_managed_group_descriptions(self):
         """Return detailed descriptions of all managed consumer groups on this cluster
 
         This function only returns descriptions for consumer groups created via the

--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -1603,3 +1603,56 @@ class LeaveGroupResponse(Response):
         fmt = 'h'
         response = struct_helpers.unpack_from(fmt, buff, 0)
         self.error_code = response[0]
+
+
+###
+# Administrative API
+###
+class ListGroupsRequest(Request):
+    """A list group request
+
+    Specification::
+
+    ListGroupsRequest =>
+    """
+    @property
+    def API_KEY(self):
+        """API_KEY for this request, from the Kafka docs"""
+        return 16
+
+    def get_bytes(self):
+        """Create a new list group request"""
+        output = bytearray(self.HEADER_LEN)
+        self._write_header(output)
+        return output
+
+    def __len__(self):
+        """Length of the serialized message, in bytes"""
+        return self.HEADER_LEN
+
+
+
+class ListGroupsResponse(Response):
+    """A list group response
+
+    Specification::
+
+    ListGroupsResponse => ErrorCode Groups
+      ErrorCode => int16
+      Groups => [GroupId ProtocolType]
+        GroupId => string
+        ProtocolType => string
+    """
+    def __init__(self, buff):
+        """Deserialize into a new Response
+
+        :param buff: Serialized message
+        :type buff: :class:`bytearray`
+        """
+        fmt = 'h [SS]'
+        response = struct_helpers.unpack_from(fmt, buff, 0)
+
+        self.error = response[0]
+        self.groups = []
+        for group_info in response[1]:
+            self.groups.append(group_info)

--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -1353,8 +1353,7 @@ class MemberAssignment(object):
             Partition => int32
         UserData => bytes
     """
-    def __init__(self, partition_assignment, member_id=None, version=1):
-        self.member_id = member_id
+    def __init__(self, partition_assignment, version=1):
         self.version = version
         self.partition_assignment = partition_assignment
 

--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -1759,8 +1759,8 @@ class DescribeGroupsResponse(Response):
         for group_info in response:
             members = {}
             for member_info in group_info[5]:
-                # TODO - parse metadata bytestring (new_member[3]) into ConsumerGroupProtocolMetadata
-                member_metadata = member_info[3]
+                member_metadata = ConsumerGroupProtocolMetadata.from_bytestring(
+                    member_info[3])
                 member_assignment = MemberAssignment.from_bytestring(member_info[4])
                 member = GroupMember(*(member_info[:3] + (member_metadata,
                                                           member_assignment)))

--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -1365,7 +1365,8 @@ class MemberAssignment(object):
             Partition => int32
         UserData => bytes
     """
-    def __init__(self, partition_assignment, version=1):
+    def __init__(self, partition_assignment, member_id=None, version=1):
+        self.member_id = member_id
         self.version = version
         self.partition_assignment = partition_assignment
 

--- a/tests/pykafka/test_protocol.py
+++ b/tests/pykafka/test_protocol.py
@@ -733,6 +733,86 @@ class TestAdministrativeAPI(unittest2.TestCase):
             )
         )
 
+    def test_list_groups_response(self):
+        response = protocol.ListGroupsResponse(
+            bytearray(
+                b'\x00\x00'  # error code
+                b'\x00\x00\x00\x01'  # len(groups)
+                    b'\x00\t'  # len(group_id)
+                        b'testgroup'  # group_id
+                    b'\x00\x08'  # len(protocol_type)
+                        b'consumer'  # protocol_type
+            )
+        )
+        self.assertEqual(len(response.groups), 1)
+        group = response.groups[response.groups.keys()[0]]
+        self.assertEqual(group.group_id, "testgroup")
+        self.assertEqual(group.protocol_type, "consumer")
+
+    def test_describe_groups_request(self):
+        req = protocol.DescribeGroupsRequest([b'testgroup'])
+        msg = req.get_bytes()
+        self.assertEqual(
+            msg,
+            bytearray(
+                b'\x00\x00\x00 \x00\x0f\x00\x00\x00\x00\x00\x00\x00\x07pykafka'  # header
+                b'\x00\x00\x00\x01'  # len(group_ids)
+                    b'\x00\t'  # len(group_id)
+                        b'testgroup'  # group_id
+            )
+        )
+
+    def test_describe_groups_response(self):
+        response = protocol.DescribeGroupsResponse(
+            bytearray(
+                b'\x00\x00\x00\x01'  # len(groups)
+                    b'\x00\x00'  # error code
+                    b'\x00\t'  # len(group_id)
+                        b'testgroup'  # group_id
+                    b'\x00\x06'  # len(state)
+                        b'Stable'  # state
+                    b'\x00\x08'  # len(protocol_type)
+                        b'consumer'  # protocol_type
+                    b'\x00\x19'  # len(protocol)
+                        b'pykafkaassignmentstrategy'  # protocol
+                    b'\x00\x00\x00\x01'  # len(members)
+                        b'\x00,'  # len(member_id)
+                            b'pykafka-d42426fb-c295-4cd9-b585-6dd79daf3afe'  # member_id
+                        b'\x00\x07'  # len(client_id)
+                            b'pykafka'  # client_id
+                        b'\x00\n'  # len(client_host)
+                            b'/127.0.0.1'  # client_host
+                        b'\x00\x00\x00'  # len(member_metadata)
+                            b'\x00\x00\x00\x00\x00\x01\x00\ndummytopic\x00\x00\x00\x0ctestuserdata'
+                        b'\x00\x00\x00H'  # len(member_assignment)
+                            b'\x00\x01\x00\x00\x00\x01\x00\x14testtopic_replicated'  # member_assignment
+                            b'\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00'
+                            b'\x02\x00\x00\x00\x08\x00\x00\x00\x03\x00\x00\x00\t'
+                            b'\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x06'
+                            b'\x00\x00\x00\x07\x00\x00\x00\x00'
+            )
+        )
+        self.assertTrue('testgroup' in response.groups)
+        group_response = response.groups['testgroup']
+        self.assertEqual(group_response.error_code, 0)
+        self.assertEqual(group_response.group_id, 'testgroup')
+        self.assertEqual(group_response.state, 'Stable')
+        self.assertEqual(group_response.protocol_type, 'consumer')
+        self.assertEqual(group_response.protocol, 'pykafkaassignmentstrategy')
+        member_id = 'pykafka-d42426fb-c295-4cd9-b585-6dd79daf3afe'
+        self.assertTrue(member_id in group_response.members)
+        member = group_response.members[member_id]
+        self.assertEqual(member.member_id, member_id)
+        self.assertEqual(member.client_id, 'pykafka')
+        self.assertEqual(member.client_host, '/127.0.0.1')
+        self.assertEqual(
+            member.member_metadata,
+            b'\x00\x00\x00\x00\x00\x01\x00\ndummytopic\x00\x00\x00\x0ctestuserdata')
+        assignment = member.member_assignment
+        self.assertEqual(assignment.version, 1)
+        self.assertEqual(assignment.partition_assignment,
+                         [('testtopic_replicated', [0, 1, 2, 8, 3, 9, 4, 5, 6, 7])])
+
 
 if __name__ == '__main__':
     unittest2.main()

--- a/tests/pykafka/test_protocol.py
+++ b/tests/pykafka/test_protocol.py
@@ -747,9 +747,9 @@ class TestAdministrativeAPI(unittest2.TestCase):
             )
         )
         self.assertEqual(len(response.groups), 1)
-        group = response.groups[response.groups.keys()[0]]
-        self.assertEqual(group.group_id, "testgroup")
-        self.assertEqual(group.protocol_type, "consumer")
+        group = response.groups[b"testgroup"]
+        self.assertEqual(group.group_id, b"testgroup")
+        self.assertEqual(group.protocol_type, b"consumer")
 
     def test_describe_groups_request(self):
         req = protocol.DescribeGroupsRequest([b'testgroup'])
@@ -794,19 +794,19 @@ class TestAdministrativeAPI(unittest2.TestCase):
                             b'\x00\x00\x00\x07\x00\x00\x00\x00'
             )
         )
-        self.assertTrue('testgroup' in response.groups)
-        group_response = response.groups['testgroup']
+        self.assertTrue(b'testgroup' in response.groups)
+        group_response = response.groups[b'testgroup']
         self.assertEqual(group_response.error_code, 0)
-        self.assertEqual(group_response.group_id, 'testgroup')
-        self.assertEqual(group_response.state, 'Stable')
-        self.assertEqual(group_response.protocol_type, 'consumer')
-        self.assertEqual(group_response.protocol, 'pykafkaassignmentstrategy')
-        member_id = 'pykafka-d42426fb-c295-4cd9-b585-6dd79daf3afe'
+        self.assertEqual(group_response.group_id, b'testgroup')
+        self.assertEqual(group_response.state, b'Stable')
+        self.assertEqual(group_response.protocol_type, b'consumer')
+        self.assertEqual(group_response.protocol, b'pykafkaassignmentstrategy')
+        member_id = b'pykafka-d42426fb-c295-4cd9-b585-6dd79daf3afe'
         self.assertTrue(member_id in group_response.members)
         member = group_response.members[member_id]
         self.assertEqual(member.member_id, member_id)
-        self.assertEqual(member.client_id, 'pykafka')
-        self.assertEqual(member.client_host, '/127.0.0.1')
+        self.assertEqual(member.client_id, b'pykafka')
+        self.assertEqual(member.client_host, b'/127.0.0.1')
         metadata = member.member_metadata
         self.assertEqual(metadata.version, 0)
         self.assertEqual(metadata.topic_names, [b"dummytopic"])
@@ -814,7 +814,7 @@ class TestAdministrativeAPI(unittest2.TestCase):
         assignment = member.member_assignment
         self.assertEqual(assignment.version, 1)
         self.assertEqual(assignment.partition_assignment,
-                         [('testtopic_replicated', [0, 1, 2, 8, 3, 9, 4, 5, 6, 7])])
+                         [(b'testtopic_replicated', [0, 1, 2, 8, 3, 9, 4, 5, 6, 7])])
 
 
 if __name__ == '__main__':

--- a/tests/pykafka/test_protocol.py
+++ b/tests/pykafka/test_protocol.py
@@ -720,5 +720,19 @@ class TestGroupMembershipAPI(unittest2.TestCase):
         self.assertEqual(response.error_code, 0)
 
 
+class TestAdministrativeAPI(unittest2.TestCase):
+    maxDiff = None
+
+    def test_list_groups_request(self):
+        req = protocol.ListGroupsRequest()
+        msg = req.get_bytes()
+        self.assertEqual(
+            msg,
+            bytearray(
+                b'\x00\x00\x00\x11\x00\x10\x00\x00\x00\x00\x00\x00\x00\x07pykafka'  # header
+            )
+        )
+
+
 if __name__ == '__main__':
     unittest2.main()

--- a/tests/pykafka/test_protocol.py
+++ b/tests/pykafka/test_protocol.py
@@ -784,7 +784,7 @@ class TestAdministrativeAPI(unittest2.TestCase):
                             b'pykafka'  # client_id
                         b'\x00\n'  # len(client_host)
                             b'/127.0.0.1'  # client_host
-                        b'\x00\x00\x00'  # len(member_metadata)
+                        b'\x00\x00\x00"'  # len(member_metadata)
                             b'\x00\x00\x00\x00\x00\x01\x00\ndummytopic\x00\x00\x00\x0ctestuserdata'
                         b'\x00\x00\x00H'  # len(member_assignment)
                             b'\x00\x01\x00\x00\x00\x01\x00\x14testtopic_replicated'  # member_assignment
@@ -807,9 +807,10 @@ class TestAdministrativeAPI(unittest2.TestCase):
         self.assertEqual(member.member_id, member_id)
         self.assertEqual(member.client_id, 'pykafka')
         self.assertEqual(member.client_host, '/127.0.0.1')
-        self.assertEqual(
-            member.member_metadata,
-            b'\x00\x00\x00\x00\x00\x01\x00\ndummytopic\x00\x00\x00\x0ctestuserdata')
+        metadata = member.member_metadata
+        self.assertEqual(metadata.version, 0)
+        self.assertEqual(metadata.topic_names, [b"dummytopic"])
+        self.assertEqual(metadata.user_data, b"testuserdata")
         assignment = member.member_assignment
         self.assertEqual(assignment.version, 1)
         self.assertEqual(assignment.partition_assignment,


### PR DESCRIPTION
This pull request builds on #620 to provide support for Kafka 0.10's administrative API. It adds support for `ListGroupsRequest` and `DescribeGroupsRequest`, as well as a convenience function `Cluster.get_managed_group_descriptions`.

These changes require a minor version increment.