### PR TITLE
remove member_id from MemberAssignment

### DIFF
--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -279,11 +279,12 @@ class ManagedBalancedConsumer(BalancedConsumer):
                 # generate partition assignments for each group member
                 # if this is not the leader, join_result.members will be empty
                 group_assignments = [
-                    MemberAssignment([
+                    (member_id,
+                     MemberAssignment([
                         (self._topic.name,
                          [p.id for p in self._decide_partitions(
-                          iterkeys(members), consumer_id=member_id)])
-                    ], member_id=member_id) for member_id in members]
+                          iterkeys(members), consumer_id=member_id)])])
+                    ) for member_id in members]
 
                 assignment = self._sync_group(group_assignments)
                 self._setup_internal_consumer(

--- a/tests/pykafka/test_protocol.py
+++ b/tests/pykafka/test_protocol.py
@@ -636,10 +636,10 @@ class TestGroupMembershipAPI(unittest2.TestCase):
         req = protocol.SyncGroupRequest(
             b'dummygroup', 1, b'testmember1',
             [
-                protocol.MemberAssignment([(b"mytopic1", [3, 5, 7, 9]),
-                                           (b"mytopic2", [3, 5, 7, 9])], member_id=b"a"),
-                protocol.MemberAssignment([(b"mytopic1", [2, 4, 6, 8]),
-                                           (b"mytopic2", [2, 4, 6, 8])], member_id=b"b")
+                (b"a", protocol.MemberAssignment([(b"mytopic1", [3, 5, 7, 9]),
+                                                  (b"mytopic2", [3, 5, 7, 9])])),
+                (b"b", protocol.MemberAssignment([(b"mytopic1", [2, 4, 6, 8]),
+                                                  (b"mytopic2", [2, 4, 6, 8])]))
             ])
         msg = req.get_bytes()
         self.assertEqual(


### PR DESCRIPTION
This pull request removes the `member_id` attribute from the `MemberAssignment` class. This makes the class match the `MemberAssignment` schema from the pykafka protocol documentation.