### PR TITLE
reraise worker thread exceptions

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -217,7 +217,6 @@ class BalancedConsumer(object):
         self._generation_id = -1
         self._running = False
         self._worker_exception = None
-        self._worker_trace_logged = False
         self._is_compacted_topic = compacted_topic
 
         if not rdkafka and use_rdkafka:

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -23,7 +23,6 @@ import logging
 import socket
 import sys
 import time
-import traceback
 from uuid import uuid4
 import weakref
 

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -31,6 +31,7 @@ from kazoo.client import KazooClient
 from kazoo.handlers.gevent import SequentialGeventHandler
 from kazoo.exceptions import NoNodeException, NodeExistsError
 from kazoo.recipe.watchers import ChildrenWatch
+from six import reraise
 
 from .common import OffsetType
 from .exceptions import KafkaException, PartitionOwnedError, ConsumerStoppedException
@@ -263,12 +264,7 @@ class BalancedConsumer(object):
     def _raise_worker_exceptions(self):
         """Raises exceptions encountered on worker threads"""
         if self._worker_exception is not None:
-            _, ex, tb = self._worker_exception
-            if not self._worker_trace_logged:
-                self._worker_trace_logged = True
-                log.error("Exception encountered in worker thread:\n%s",
-                          "".join(traceback.format_tb(tb)))
-            raise ex
+            reraise(*self._worker_exception)
 
     @property
     def topic(self):

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -197,7 +197,6 @@ class ManagedBalancedConsumer(BalancedConsumer):
         self._consumer = None
         self._group_coordinator = None
         self._consumer_id = b''
-        self._worker_trace_logged = False
         self._worker_exception = None
         self._default_error_handlers = self._build_default_error_handlers()
 

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -23,7 +23,6 @@ import logging
 import platform
 import sys
 import threading
-import traceback
 import weakref
 
 from six import reraise

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -26,6 +26,8 @@ import threading
 import traceback
 import weakref
 
+from six import reraise
+
 from .common import CompressionType
 from .exceptions import (
     ERROR_CODES,
@@ -193,15 +195,7 @@ class Producer(object):
     def _raise_worker_exceptions(self):
         """Raises exceptions encountered on worker threads"""
         if self._worker_exception is not None:
-            _, ex, tb = self._worker_exception
-            # avoid logging worker exceptions more than once, which can
-            # happen when this function's `raise` triggers `__exit__`
-            # which calls `stop`
-            if not self._worker_trace_logged:
-                self._worker_trace_logged = True
-                log.error("Exception encountered in worker thread:\n%s",
-                          "".join(traceback.format_tb(tb)))
-            raise ex
+            reraise(*self._worker_exception)
 
     def __repr__(self):
         return "<{module}.{name} at {id_}>".format(

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -175,7 +175,6 @@ class Producer(object):
         self._max_request_size = valid_int(max_request_size)
         self._synchronous = sync
         self._worker_exception = None
-        self._worker_trace_logged = False
         self._owned_brokers = None
         self._delivery_reports = (_DeliveryReportQueue(self._cluster.handler)
                                   if delivery_reports or self._synchronous

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -25,7 +25,6 @@ import socket
 import sys
 import threading
 import time
-import traceback
 from collections import defaultdict
 import weakref
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -185,7 +185,6 @@ class SimpleConsumer(object):
         self._auto_commit_interval_ms = valid_int(auto_commit_interval_ms)
         self._last_auto_commit = time.time()
         self._worker_exception = None
-        self._worker_trace_logged = False
         self._update_lock = self._cluster.handler.Lock()
 
         self._discover_group_coordinator()

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -29,6 +29,8 @@ import traceback
 from collections import defaultdict
 import weakref
 
+from six import reraise
+
 from .common import OffsetType
 from .utils.compat import (Queue, Empty, iteritems, itervalues,
                            range, iterkeys, get_bytes, get_string)
@@ -226,12 +228,7 @@ class SimpleConsumer(object):
     def _raise_worker_exceptions(self):
         """Raises exceptions encountered on worker threads"""
         if self._worker_exception is not None:
-            _, ex, tb = self._worker_exception
-            if not self._worker_trace_logged:
-                self._worker_trace_logged = True
-                log.error("Exception encountered in worker thread:\n%s",
-                          "".join(traceback.format_tb(tb)))
-            raise ex
+            reraise(*self._worker_exception)
 
     def _update(self):
         """Update the consumer and cluster after an ERROR_CODE"""


### PR DESCRIPTION
This pull request fixes a longstanding issue with thread exception reporting. Previously, exceptions encountered on worker threads were logged and then raised via a handler on the main thread. This exception on the main thread didn't include the worker's traceback, making it hard to debug and report thread crashes. Here, we change this logic to use `six.reraise` to include the worker's traceback in the exception raised on the main thread.