### PR TITLE
SimpleConsumer: add deprecated to docstring

### DIFF
--- a/pykafka/client.py
+++ b/pykafka/client.py
@@ -23,7 +23,6 @@ from .handlers import ThreadingHandler, GEventHandler
 import logging
 
 from .cluster import Cluster
-from .handlers import ThreadingHandler
 
 
 log = logging.getLogger(__name__)

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -189,7 +189,8 @@ class InconsistentGroupProtocol(ProtocolClientError):
 
 class UnknownMemberId(ProtocolClientError):
     """Returned from group requests (offset commits/fetches, heartbeats, etc) when the
-        memberId is not in the current generation.
+        memberId is not in the current generation. Also returned if SimpleConsumer is
+        incorrectly instantiated with a non-default consumer_id.
     """
     ERROR_CODE = 25
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -142,10 +142,12 @@ class SimpleConsumer(object):
             consumer to use less stringent message ordering logic because compacted
             topics do not provide offsets in stict incrementing order.
         :type compacted_topic: bool
-        :param generation_id: The generation id with which to make group requests
+        :param generation_id: Deprecated::2.7 Do not set if directly instantiating
+            SimpleConsumer. The generation id with which to make group requests
         :type generation_id: int
-        :param consumer_id: The identifying string to use for this consumer on group
-            requests
+        :param consumer_id: Deprecated::2.7 Do not set if directly instantiating
+            SimpleConsumer. The identifying string to use for this consumer on
+            group requests
         :type consumer_id: bytes
         """
         self._running = False


### PR DESCRIPTION
SimpleConsumer: add deprecated to docstring.

SimpleConsumer constructor params: generation_id, consumer_id are marked as deprecated in docstring

Also extend docstring for UnknownMemberId to explain one cause of the error

https://github.com/Parsely/pykafka/issues/630