### PR TITLE
allow NoBrokersAvailableError to bubble to main thread

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -446,10 +446,7 @@ class Producer(object):
             log.warning('Error encountered when producing to broker %s:%s. Retrying.',
                         owned_broker.broker.host,
                         owned_broker.broker.port)
-            try:
-                self._update()
-            except NoBrokersAvailableError:
-                log.warning("No brokers available")
+            self._update()
             to_retry = [
                 (mset, exc)
                 for topic, partitions in iteritems(req.msets)


### PR DESCRIPTION
This pull request fixes #629 by allowing `NoBrokersAvailable` to be raised to the main thread. This exception was caught as part of #450, but doing so introduced the issue mentioned in #629.