### PR TITLE
raise connection failure exceptions from BrokerConnection.connect()

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -95,7 +95,11 @@ class Broker(object):
         self._offsets_channel_socket_timeout_ms = offsets_channel_socket_timeout_ms
         self._buffer_size = buffer_size
         self._req_handlers = {}
-        self.connect()
+        try:
+            self.connect()
+        except SocketDisconnectedError:
+            log.warning("Failed to connect newly created broker for {host}:{port}".format(
+                host=self._host, port=self._port))
 
     def __repr__(self):
         return "<{module}.{name} at {id_} (host={host}, port={port}, id={my_id})>".format(

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -354,10 +354,9 @@ class Cluster(object):
                     ssl_config=self._ssl_config)
             elif not self._brokers[id_].connected:
                 log.info('Reconnecting to broker id %s: %s:%s', id_, meta.host, meta.port)
-                import socket
                 try:
                     self._brokers[id_].connect()
-                except socket.error:
+                except SocketDisconnectedError:
                     log.info('Failed to re-establish connection with broker id %s: %s:%s',
                              id_, meta.host, meta.port)
             else:

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -170,8 +170,8 @@ class BrokerConnection(object):
                 ))
         except (self._handler.SockErr, self._handler.GaiError):
             log.error("Failed to connect to %s:%s", self.host, self.port)
-        if self._socket is not None:
-            log.debug("Successfully connected to %s:%s", self.host, self.port)
+            raise SocketDisconnectedError
+        log.debug("Successfully connected to %s:%s", self.host, self.port)
 
     def disconnect(self):
         """Disconnect from the broker."""


### PR DESCRIPTION
This pull request is a first attempt at fixing #635. It makes `BrokerConnection.connect()` raise exceptions on connection failure instead of silently passing. This also means that callers become responsible for handling this exception, which in most cases they apparently already are. In the few cases where they are not are fixed by this pull request.

@smueller18 please feel free to test this branch and let me know if you have suggestions or clarifications. Thanks.