### PR TITLE
fix deadlock: #633, when queue is full

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -524,6 +524,10 @@ class OwnedBroker(object):
         if self._auto_start:
             self.start()
 
+    def cleanup(self):
+        if not self.slot_available.is_set():
+            self.slot_available.set()
+
     def start(self):
         def queue_reader():
             while self.running:
@@ -534,9 +538,8 @@ class OwnedBroker(object):
                 except Exception:
                     # surface all exceptions to the main thread
                     self.producer._worker_exception = sys.exc_info()
-                    if not self.slot_available.is_set():
-                        self.slot_available.set()
                     break
+            self.cleanup()
             log.info("Worker exited for broker %s:%s", self.broker.host,
                      self.broker.port)
         log.info("Starting new produce worker for broker %s", self.broker.id)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -539,7 +539,7 @@ class OwnedBroker(object):
                 except Exception:
                     # surface all exceptions to the main thread
                     self.producer._worker_exception = sys.exc_info()
-                    if not self.running and not self.slot_available.is_set():
+                    if not self.slot_available.is_set():
                         self.slot_available.set()
                     break
             log.info("Worker exited for broker %s:%s", self.broker.host,

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -225,7 +225,6 @@ class Producer(object):
         was triggered
         """
         # only allow one thread to be updating the producer at a time
-
         with self._update_lock:
             if self._owned_brokers is not None:
                 for owned_broker in list(self._owned_brokers.values()):
@@ -369,16 +368,12 @@ class Producer(object):
         """
         success = False
         while not success:
-            owned_broker = None
-            with self._update_lock:
-                leader_id = self._topic.partitions[message.partition_id].leader.id
-                if leader_id in self._owned_brokers:
-                    owned_broker = self._owned_brokers[leader_id]
-                    success = True
-                else:
-                    success = False
-            if success:
-                owned_broker.enqueue(message)
+            leader_id = self._topic.partitions[message.partition_id].leader.id
+            if leader_id in self._owned_brokers:
+                self._owned_brokers[leader_id].enqueue(message)
+                success = True
+            else:
+                success = False
 
     def _send_request(self, message_batch, owned_broker):
         """Send the produce request to the broker and handle the response.


### PR DESCRIPTION
The bug can be re-generated.
1)  start a python script to produce message infinitely ;
2)  stop Kafka service
3)  then, the python script will hang forever.
