### PR TITLE
remove noisy exception logging for SocketDisconnectedError

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -249,6 +249,9 @@ class Cluster(object):
                     response = broker.request_metadata(topics)
                     if response is not None:
                         return response
+                except SocketDisconnectedError:
+                    log.error("Socket disconnected during metadata request for "
+                              "broker %s:%s. Continuing.", host, port)
                 except Exception as e:
                     log.error('Unable to connect to broker %s:%s. Continuing.', host, port)
                     log.exception(e)


### PR DESCRIPTION
As pointed out in #636, the stack trace of `SocketDisconnectedError` was always printed on unsuccessful connection tries. This commit handles `SocketDisconnectedError`s separately and only prints a short log message.