### PR TITLE
deadlock insurance

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -667,7 +667,9 @@ class OwnedBroker(object):
                 if len(self.queue) >= self.producer._max_queued_messages:
                     self.slot_available.clear()
             if self.producer._block_on_queue_full:
-                self.slot_available.wait()
+                while not self.slot_available.is_set():
+                    self.producer._cluster.handler.sleep()
+                    self.slot_available.wait(5)
             else:
                 raise ProducerQueueFullError("Queue full for broker %d",
                                              self.broker.id)

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -778,7 +778,9 @@ class SimpleConsumer(object):
                 self._slot_available.clear()
             for op in itervalues(self._partitions):
                 op.fetch_lock.release()
-            self._slot_available.wait()
+            while not self._slot_available.is_set():
+                self._cluster.handler.sleep()
+                self._slot_available.wait()
 
 
 class OwnedPartition(object):

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -780,7 +780,7 @@ class SimpleConsumer(object):
                 op.fetch_lock.release()
             while not self._slot_available.is_set():
                 self._cluster.handler.sleep()
-                self._slot_available.wait()
+                self._slot_available.wait(5)
 
 
 class OwnedPartition(object):


### PR DESCRIPTION
This pull request changes calls to `wait()` on some thread synchronization variables to be non-blocking. This amounts to generalized insurance against deadlock scenarios in which these variables are involved. It will theoretically have a minor negative effect on CPU usage since the thread will wake up periodically, but this effect should be negligible, especially in situations where throughput is high enough that the blocking `wait()` would never take more than 5 seconds.