### PR TITLE
Downgrade to WARNING because it's always retried.

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -169,7 +169,7 @@ class BrokerConnection(object):
                     (self.source_host, self.source_port)
                 ))
         except (self._handler.SockErr, self._handler.GaiError):
-            log.warning("Failed to connect to %s:%s", self.host, self.port)
+            log.info("Failed to connect to %s:%s", self.host, self.port)
             raise SocketDisconnectedError
         log.debug("Successfully connected to %s:%s", self.host, self.port)
 

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -169,7 +169,7 @@ class BrokerConnection(object):
                     (self.source_host, self.source_port)
                 ))
         except (self._handler.SockErr, self._handler.GaiError):
-            log.error("Failed to connect to %s:%s", self.host, self.port)
+            log.warning("Failed to connect to %s:%s", self.host, self.port)
             raise SocketDisconnectedError
         log.debug("Successfully connected to %s:%s", self.host, self.port)
 


### PR DESCRIPTION
Hello Mr @emmett9001. This doesn't really need to show up in our logs, since it's just going to get retried anyway.