### PR TITLE
Include LICENSE file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.txt
+include LICENSE


### PR DESCRIPTION
Most distributions require that license files
to be included in sources tarballs.

Currently doing the Fedora/RDO package.