### PR TITLE
Fix docs so offset refers to broker not consumer group

### DIFF
--- a/pykafka/cli/kafka_tools.py
+++ b/pykafka/cli/kafka_tools.py
@@ -319,10 +319,10 @@ def _get_arg_parser():
     _add_topic(parser)
     _add_consumer_group(parser)
 
-    # Print Offsets
+    # Print Broker Offsets
     parser = subparsers.add_parser(
         'print_offsets',
-        help='Fetch offsets for a topic/consumer group'
+        help='Fetch broker offsets for a topic'
     )
     parser.set_defaults(func=print_offsets)
     _add_topic(parser)


### PR DESCRIPTION
It says consumer group, but it appears that it's actually returning broker offsets such as the highwater mark, old message still in the log, etc. It doesn't even take a consumer group as an argument.