### PR TITLE
set and use produce.offset.report

### DIFF
--- a/pykafka/rdkafka/_rd_kafkamodule.c
+++ b/pykafka/rdkafka/_rd_kafkamodule.c
@@ -553,6 +553,10 @@ Producer_delivery_report_callback(rd_kafka_t *rk,
     /* Producer_produce sent *Message as msg_opaque == rkmessage->_private */
     PyObject *message = (PyObject *)rkmessage->_private;
     PyObject *put_func = (PyObject *)opaque;
+    if (rkmessage->offset != -1) {
+        PyObject* offset = PyLong_FromUnsignedLongLong(rkmessage->offset);
+        PyObject_SetAttrString(message, "offset", offset);
+    }
     if (-1 == Producer_delivery_report_put(put_func, message, rkmessage->err)) {
         /* Must swallow exception as this is a non-python callback */
         PyObject *res = PyObject_CallMethod(

--- a/pykafka/rdkafka/producer.py
+++ b/pykafka/rdkafka/producer.py
@@ -184,7 +184,7 @@ class RdKafkaProducer(Producer):
             "message.timeout.ms": 1.2 * self._max_retries * (
                 self._ack_timeout_ms + self._retry_backoff_ms),
 
-            # "produce.offset.report"
+            "produce.offset.report": self._delivery_reports.queue is not None,
             # "partitioner"  # dealt with in pykafka
             # "opaque"
         }

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -106,6 +106,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
         report = prod.get_delivery_report()
         self.assertEqual(report[0].value, payload)
         self.assertIsNone(report[1])
+        self.assertGreaterEqual(report[0].offset, 0)
 
         message = consumer.consume()
         assert message.value == payload


### PR DESCRIPTION
Allow to ask for and obtain the offset in the delivery_reports.
I'm not sure how to do this in the non-rdkafka case, pointers would be appreciated.
