### PR TITLE
Relegate missing rdkafka traceback to DEBUG logs

### DIFF
--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -40,7 +40,8 @@ try:
     log.info("Successfully loaded pykafka.rdkafka extension.")
 except ImportError:
     rdkafka = False
-    log.info("Could not load pykafka.rdkafka extension.", exc_info=True)
+    log.info("Could not load pykafka.rdkafka extension.")
+    log.debug("Traceback:", exc_info=True)
 
 
 class Topic(object):


### PR DESCRIPTION
It's rather annoying to get the full traceback every time a program starts with INFO-level logging; this relegates the traceback to DEBUG level.