### PR TITLE
fix balancedconsumer busywaiting when no partitions are assigned

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -730,10 +730,10 @@ class BalancedConsumer(object):
         message = None
         self._last_message_time = time.time()
         while message is None and not consumer_timed_out():
-            while not self._internal_consumer_running.is_set():
+            if not self._internal_consumer_running.is_set():
                 self._cluster.handler.sleep()
                 self._raise_worker_exceptions()
-                self._internal_consumer_running.wait(5)
+                self._internal_consumer_running.wait(self._consumer_timeout_ms / 1000)
             try:
                 # acquire the lock to ensure that we don't start trying to consume from
                 # a _consumer that might soon be replaced by an in-progress rebalance

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -742,7 +742,6 @@ class BalancedConsumer(object):
             except (ConsumerStoppedException, AttributeError):
                 if not self._running:
                     raise ConsumerStoppedException
-                continue
             if message:
                 self._last_message_time = time.time()
             if not block:

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -194,6 +194,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
 
         self._generation_id = -1
         self._rebalancing_lock = cluster.handler.Lock()
+        self._internal_consumer_running = self._cluster.handler.Event()
         # ManagedBalancedConsumers in the same process cannot share connections.
         # This connection hash is passed to Broker calls that use the group
         # membership  API


### PR DESCRIPTION
This pull request fixes #628 by using an `Event` to perform a quiet wait in cases where no partitions are available for consumption and `BalancedConsumer._consumer == None`.