### PR TITLE
Simplify cli usage

### DIFF
--- a/pykafka/cli/__main__.py
+++ b/pykafka/cli/__main__.py
@@ -1,0 +1,3 @@
+
+from .kafka_tools import main
+main()


### PR DESCRIPTION
Can do `python3 -m pykafka.cli ...` without having to know where pykafka
installed to.

Before submitting with updated docs, wanted to gauge interest.  Not sure how popular this pattern is with the general community.