### PR TITLE
raise SocketDisconnectedError with host and port args

### DIFF
--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -170,7 +170,7 @@ class BrokerConnection(object):
                 ))
         except (self._handler.SockErr, self._handler.GaiError):
             log.info("Failed to connect to %s:%s", self.host, self.port)
-            raise SocketDisconnectedError
+            raise SocketDisconnectedError("<broker %s:%s>" % (self.host, self.port))
         log.debug("Successfully connected to %s:%s", self.host, self.port)
 
     def disconnect(self):
@@ -193,13 +193,13 @@ class BrokerConnection(object):
         """Send a request over the socket connection"""
         bytes_ = request.get_bytes()
         if not self._socket:
-            raise SocketDisconnectedError
+            raise SocketDisconnectedError("<broker %s:%s>" % (self.host, self.port))
         try:
             self._socket.sendall(bytes_)
         except self._handler.SockErr as e:
             log.error("Failed to send data, error: %s" % repr(e))
             self.disconnect()
-            raise SocketDisconnectedError
+            raise SocketDisconnectedError("<broker %s:%s>" % (self.host, self.port))
 
     def response(self):
         """Wait for a response from the broker"""
@@ -213,13 +213,13 @@ class BrokerConnection(object):
             if r is None or len(r) == 0:
                 # Happens when broker has shut down
                 self.disconnect()
-                raise SocketDisconnectedError
+                raise SocketDisconnectedError("<broker %s:%s>" % (self.host, self.port))
             size += r
         size = struct.unpack('!i', size)[0]
         try:
             recvall_into(self._socket, self._buff, size)
         except SocketDisconnectedError:
             self.disconnect()
-            raise
+            raise SocketDisconnectedError("<broker %s:%s>" % (self.host, self.port))
         # Drop CorrelationId => int32
         return buffer(self._buff[4:4 + size])


### PR DESCRIPTION
when raise SocketDisconnectedError without host and port , we have no idea which broker has network issue.