### PR TITLE
Fix bytestring input to struct.pack_into() in Python 3

### DIFF
--- a/pykafka/protocol.py
+++ b/pykafka/protocol.py
@@ -1119,7 +1119,8 @@ class OffsetCommitRequest(Request):
         struct.pack_into(fmt, output, offset,
                          len(self.consumer_group), self.consumer_group,
                          self.consumer_group_generation_id,
-                         len(self.consumer_id), self.consumer_id,
+                         len(self.consumer_id),
+                         self.consumer_id.encode('utf-8'),
                          len(self._reqs))
 
         offset += struct.calcsize(fmt)
@@ -1138,7 +1139,8 @@ class OffsetCommitRequest(Request):
                 pack_args = [fmt, output, offset, metalen]
                 if metalen != -1:
                     fmt += '%ds' % metalen
-                    pack_args = [fmt, output, offset, metalen, metadata]
+                    pack_args = [fmt, output, offset, metalen,
+                                 metadata.encode('utf-8')]
                 struct.pack_into(*pack_args)
                 offset += struct.calcsize(fmt)
         return output


### PR DESCRIPTION
I got the following error using python 3.5:
```
mortada ~ $ kafka-tools -b x.x.x.x:x reset_offsets topic group EARLIEST
Traceback (most recent call last):
  File "/Users/mortada/anaconda/bin/kafka-tools", line 11, in <module>
    sys.exit(main())
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/cli/kafka_tools.py", line 354, in main
    args.func(client, args)
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/cli/kafka_tools.py", line 230, in reset_offsets
    args.consumer_group, 1, 'kafka-tools', reqs
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/broker.py", line 390, in commit_consumer_group_offsets
    return self._offsets_channel_req_handler.request(req).get(OffsetCommitResponse)
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/handlers.py", line 70, in get
    raise self.error
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/handlers.py", line 205, in worker
    shared.connection.request(task.request)
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/connection.py", line 194, in request
    bytes_ = request.get_bytes()
  File "/Users/mortada/anaconda/lib/python3.5/site-packages/pykafka/protocol.py", line 1025, in get_bytes
    len(self._reqs))
struct.error: argument for 's' must be a bytes object
```

This is because in python 3 the input to `struct.pack_info()` would be `str` instead of `bytes`. This PR will fix the error above.