### PR TITLE
Use longer sleep in SimpleConsumer.fetcher

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -400,7 +400,7 @@ class SimpleConsumer(object):
                     if not self._running:
                         break
                     self.fetch()
-                    self._cluster.handler.sleep(.0001)
+                    self._cluster.handler.sleep(.01)
                 except ReferenceError:
                     break
                 except Exception:


### PR DESCRIPTION
This reverts commit 43ee0ec55636bfc6a84d47f1c127f3d20215c6f3, for which I could not find a rationale.

In our project, we've found that this incredibly short sleep causes high (~20%) CPU usage at idle.  There are also a couple of `sleep()` calls in simpleconsumer.py (lines 441 and 802) that don't appear to do anything but burn a bit of CPU, though removing them is not included in this PR.