### PR TITLE
debug logging for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false
+sudo: required
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
The Travis VM pykafka was given appears to have broken. This change ensures that we always get a fresh VM on Travis.