### PR TITLE
encode consumer groups and topic names as ascii bytestrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 .cache
 *.so
 .rnd
+.pytest_cache

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -207,7 +207,7 @@ class BalancedConsumer(object):
         """
         self._cluster = cluster
         try:
-            self._consumer_group = consumer_group.encode('ascii')
+            self._consumer_group = str(consumer_group).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                    "characters".format(consumer_group))

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -35,7 +35,8 @@ except ImportError:
 from six import reraise
 
 from .common import OffsetType
-from .exceptions import KafkaException, PartitionOwnedError, ConsumerStoppedException
+from .exceptions import (KafkaException, PartitionOwnedError, ConsumerStoppedException,
+                         UnicodeException)
 from .membershipprotocol import RangeProtocol
 from .simpleconsumer import SimpleConsumer
 from .utils.compat import range, get_bytes, itervalues, iteritems, get_string
@@ -205,7 +206,11 @@ class BalancedConsumer(object):
         :type membership_protocol: :class:`pykafka.membershipprotocol.GroupMembershipProtocol`
         """
         self._cluster = cluster
-        self._consumer_group = consumer_group.encode('ascii')
+        try:
+            self._consumer_group = consumer_group.encode('ascii')
+        except UnicodeEncodeError:
+            raise UnicodeException("Consumer group name '{}' contains non-ascii "
+                                   "characters".format(consumer_group))
         self._topic = topic
 
         self._auto_commit_enable = auto_commit_enable

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -207,7 +207,7 @@ class BalancedConsumer(object):
         """
         self._cluster = cluster
         try:
-            self._consumer_group = str(consumer_group).encode('ascii')
+            self._consumer_group = get_string(consumer_group).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                    "characters".format(consumer_group))

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -112,7 +112,7 @@ class BalancedConsumer(object):
             should join. Consumer group names are namespaced at the cluster level,
             meaning that two consumers consuming different topics with the same group name
             will be treated as part of the same group.
-        :type consumer_group: bytes
+        :type consumer_group: str
         :param fetch_message_max_bytes: The number of bytes of messages to
             attempt to fetch with each fetch request
         :type fetch_message_max_bytes: int

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -205,9 +205,7 @@ class BalancedConsumer(object):
         :type membership_protocol: :class:`pykafka.membershipprotocol.GroupMembershipProtocol`
         """
         self._cluster = cluster
-        if not isinstance(consumer_group, bytes):
-            raise TypeError("consumer_group must be a bytes object")
-        self._consumer_group = consumer_group
+        self._consumer_group = consumer_group.encode('ascii')
         self._topic = topic
 
         self._auto_commit_enable = auto_commit_enable

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -38,7 +38,7 @@ from .exceptions import (ERROR_CODES,
 from .protocol import (GroupCoordinatorRequest, GroupCoordinatorResponse,
                        API_VERSIONS_090, API_VERSIONS_080)
 from .topic import Topic
-from .utils.compat import iteritems, itervalues, range
+from .utils.compat import iteritems, itervalues, range, get_string
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class TopicDict(dict):
 
     def __getitem__(self, key):
         try:
-            key = str(key).encode('ascii')
+            key = get_string(key).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Topic name '{}' contains non-ascii "
                                    "characters".format(key))

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -56,7 +56,7 @@ class TopicDict(dict):
 
     def __getitem__(self, key):
         try:
-            key = key.encode('ascii')
+            key = str(key).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Topic name '{}' contains non-ascii "
                                    "characters".format(key))

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -33,7 +33,8 @@ from .exceptions import (ERROR_CODES,
                          NoBrokersAvailableError,
                          SocketDisconnectedError,
                          LeaderNotFoundError,
-                         LeaderNotAvailable)
+                         LeaderNotAvailable,
+                         UnicodeException)
 from .protocol import (GroupCoordinatorRequest, GroupCoordinatorResponse,
                        API_VERSIONS_090, API_VERSIONS_080)
 from .topic import Topic
@@ -54,7 +55,11 @@ class TopicDict(dict):
         return [self[key] for key in self]
 
     def __getitem__(self, key):
-        key = key.encode('ascii')
+        try:
+            key = key.encode('ascii')
+        except UnicodeEncodeError:
+            raise UnicodeException("Topic name '{}' contains non-ascii "
+                                   "characters".format(key))
         if self._should_exclude_topic(key):
             raise KeyError("You have configured KafkaClient/Cluster to hide "
                            "double-underscored, internal topics")

--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -54,9 +54,7 @@ class TopicDict(dict):
         return [self[key] for key in self]
 
     def __getitem__(self, key):
-        if not isinstance(key, bytes):
-            raise TypeError("TopicDict.__getitem__ accepts a bytes object, but it "
-                            "got '%s'", type(key))
+        key = key.encode('ascii')
         if self._should_exclude_topic(key):
             raise KeyError("You have configured KafkaClient/Cluster to hide "
                            "double-underscored, internal topics")

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -23,6 +23,11 @@ class KafkaException(Exception):
     pass
 
 
+class UnicodeException(Exception):
+    """Indicates that an error was encountered while processing a unicode string"""
+    pass
+
+
 class NoBrokersAvailableError(KafkaException):
     """Indicates that no brokers were available to the cluster's metadata update attempts
     """

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -170,9 +170,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
         """
 
         self._cluster = cluster
-        if not isinstance(consumer_group, bytes):
-            raise TypeError("consumer_group must be a bytes object")
-        self._consumer_group = consumer_group
+        self._consumer_group = consumer_group.encode('ascii')
         self._topic = topic
 
         self._auto_commit_enable = auto_commit_enable

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -30,7 +30,7 @@ from .exceptions import (IllegalGeneration, RebalanceInProgress, NotCoordinatorF
                          UnicodeException)
 from .membershipprotocol import RangeProtocol
 from .protocol import MemberAssignment
-from .utils.compat import iterkeys
+from .utils.compat import iterkeys, get_string
 from .utils.error_handlers import valid_int
 
 log = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
 
         self._cluster = cluster
         try:
-            self._consumer_group = str(consumer_group).encode('ascii')
+            self._consumer_group = get_string(consumer_group).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                    "characters".format(consumer_group))

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -26,7 +26,8 @@ import weakref
 from .balancedconsumer import BalancedConsumer
 from .common import OffsetType
 from .exceptions import (IllegalGeneration, RebalanceInProgress, NotCoordinatorForGroup,
-                         GroupCoordinatorNotAvailable, ERROR_CODES, GroupLoadInProgress)
+                         GroupCoordinatorNotAvailable, ERROR_CODES, GroupLoadInProgress,
+                         UnicodeException)
 from .membershipprotocol import RangeProtocol
 from .protocol import MemberAssignment
 from .utils.compat import iterkeys
@@ -170,7 +171,11 @@ class ManagedBalancedConsumer(BalancedConsumer):
         """
 
         self._cluster = cluster
-        self._consumer_group = consumer_group.encode('ascii')
+        try:
+            self._consumer_group = consumer_group.encode('ascii')
+        except UnicodeEncodeError:
+            raise UnicodeException("Consumer group name '{}' contains non-ascii "
+                                   "characters".format(consumer_group))
         self._topic = topic
 
         self._auto_commit_enable = auto_commit_enable

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -84,7 +84,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
             should join. Consumer group names are namespaced at the cluster level,
             meaning that two consumers consuming different topics with the same group name
             will be treated as part of the same group.
-        :type consumer_group: bytes
+        :type consumer_group: str
         :param fetch_message_max_bytes: The number of bytes of messages to
             attempt to fetch with each fetch request
         :type fetch_message_max_bytes: int

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -172,7 +172,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
 
         self._cluster = cluster
         try:
-            self._consumer_group = consumer_group.encode('ascii')
+            self._consumer_group = str(consumer_group).encode('ascii')
         except UnicodeEncodeError:
             raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                    "characters".format(consumer_group))

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -25,7 +25,6 @@ import struct
 import sys
 import threading
 import weakref
-from pkg_resources import parse_version
 
 from six import reraise
 
@@ -35,7 +34,6 @@ from .exceptions import (
     KafkaException,
     InvalidMessageSize,
     MessageSizeTooLarge,
-    NoBrokersAvailableError,
     NotLeaderForPartition,
     ProducerQueueFullError,
     ProducerStoppedException,

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -161,7 +161,7 @@ class SimpleConsumer(object):
         self._consumer_group = None
         if consumer_group:
             try:
-                self._consumer_group = consumer_group.encode('ascii')
+                self._consumer_group = str(consumer_group).encode('ascii')
             except UnicodeEncodeError:
                 raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                        "characters".format(consumer_group))

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -158,9 +158,7 @@ class SimpleConsumer(object):
         """
         self._running = False
         self._cluster = cluster
-        if not (isinstance(consumer_group, bytes) or consumer_group is None):
-            raise TypeError("consumer_group must be a bytes object")
-        self._consumer_group = consumer_group
+        self._consumer_group = consumer_group.encode('ascii') if consumer_group else None
         self._topic = topic
         self._fetch_message_max_bytes = valid_int(fetch_message_max_bytes)
         self._fetch_min_bytes = valid_int(fetch_min_bytes)

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -89,7 +89,7 @@ class SimpleConsumer(object):
         :type cluster: :class:`pykafka.cluster.Cluster`
         :param consumer_group: The name of the consumer group this consumer
             should use for offset committing and fetching.
-        :type consumer_group: bytes
+        :type consumer_group: str
         :param partitions: Existing partitions to which to connect
         :type partitions: Iterable of :class:`pykafka.partition.Partition`
         :param fetch_message_max_bytes: The number of bytes of messages to

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -161,7 +161,7 @@ class SimpleConsumer(object):
         self._consumer_group = None
         if consumer_group:
             try:
-                self._consumer_group = str(consumer_group).encode('ascii')
+                self._consumer_group = get_string(consumer_group).encode('ascii')
             except UnicodeEncodeError:
                 raise UnicodeException("Consumer group name '{}' contains non-ascii "
                                        "characters".format(consumer_group))

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -40,8 +40,8 @@ class TestBalancedConsumer(unittest2.TestCase):
         cls._mock_consumer, _ = TestBalancedConsumer.buildMockConsumer(timeout=cls._consumer_timeout)
 
     @classmethod
-    def buildMockConsumer(self, num_partitions=10, num_participants=1, timeout=2000):
-        consumer_group = b'testgroup'
+    def buildMockConsumer(self, consumer_group=b'testgroup', num_partitions=10,
+                          num_participants=1, timeout=2000):
         topic = mock.Mock()
         topic.name = 'testtopic'
         topic.partitions = {}
@@ -58,6 +58,9 @@ class TestBalancedConsumer(unittest2.TestCase):
         return BalancedConsumer(topic, cluster, consumer_group,
                                 zookeeper=zk, auto_start=False, use_rdkafka=False,
                                 consumer_timeout_ms=timeout), topic
+
+    def test_unicode_consumer_group(self):
+        consumer, _ = self.buildMockConsumer(consumer_group=u'testgroup')
 
     def test_consume_returns(self):
         """Ensure that consume() returns in the amount of time it's supposed to

--- a/tests/pykafka/test_balancedconsumer.py
+++ b/tests/pykafka/test_balancedconsumer.py
@@ -120,8 +120,8 @@ class TestBalancedConsumer(unittest2.TestCase):
 
 class TestManagedBalancedConsumer(TestBalancedConsumer):
     @classmethod
-    def buildMockConsumer(self, num_partitions=10, num_participants=1, timeout=2000):
-        consumer_group = b'testgroup'
+    def buildMockConsumer(self, consumer_group=b'testgroup', num_partitions=10,
+                          num_participants=1, timeout=2000):
         topic = mock.Mock()
         topic.name = 'testtopic'
         topic.partitions = {}


### PR DESCRIPTION
This PR partially addresses https://github.com/Parsely/pykafka/issues/405 by allowing consumer group names and topic names to be provided as unicode strings. These strings are expected to consist entirely of ASCII characters, and `TopicDict.__getitem__` and `SimpleConsumer.__init__` will both raise `UnicodeException` if this is not the case. This solves the common issue of users assuming they can pass unicode strings to these functions when they previously only accepted `bytes`. It also maintains the guarantee that topic and consumer group names supplied to pykafka are compatible with the broker.
  