### PR TITLE
SerDe support

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -101,7 +101,8 @@ class BalancedConsumer(object):
                  post_rebalance_callback=None,
                  use_rdkafka=False,
                  compacted_topic=False,
-                 membership_protocol=RangeProtocol):
+                 membership_protocol=RangeProtocol,
+                 deserializer=None):
         """Create a BalancedConsumer instance
 
         :param topic: The topic this consumer should consume
@@ -204,6 +205,14 @@ class BalancedConsumer(object):
         :param membership_protocol: The group membership protocol to which this consumer
             should adhere
         :type membership_protocol: :class:`pykafka.membershipprotocol.GroupMembershipProtocol`
+        :param deserializer: A function defining how to deserialize messages returned
+            from Kafka. A function with the signature d(value, partition_key) that
+            returns a tuple of (deserialized_value, deserialized_partition_key). The
+            arguments passed to this function are the bytes representations of a
+            message's value and partition key, and the returned data should be these
+            fields transformed according to the client code's serialization logic.
+            See `pykafka.utils.__init__` for stock implemtations.
+        :type deserializer: function
         """
         self._cluster = cluster
         try:
@@ -238,6 +247,7 @@ class BalancedConsumer(object):
         self._worker_exception = None
         self._is_compacted_topic = compacted_topic
         self._membership_protocol = membership_protocol
+        self._deserializer = deserializer
 
         if not rdkafka and use_rdkafka:
             raise ImportError("use_rdkafka requires rdkafka to be installed")
@@ -436,7 +446,8 @@ class BalancedConsumer(object):
             auto_start=start,
             compacted_topic=self._is_compacted_topic,
             generation_id=self._generation_id,
-            consumer_id=self._consumer_id
+            consumer_id=self._consumer_id,
+            deserializer=self._deserializer
         )
 
     def _get_participants(self):

--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -73,7 +73,8 @@ class ManagedBalancedConsumer(BalancedConsumer):
                  use_rdkafka=False,
                  compacted_topic=True,
                  heartbeat_interval_ms=3000,
-                 membership_protocol=RangeProtocol):
+                 membership_protocol=RangeProtocol,
+                 deserializer=None):
         """Create a ManagedBalancedConsumer instance
 
         :param topic: The topic this consumer should consume
@@ -168,6 +169,14 @@ class ManagedBalancedConsumer(BalancedConsumer):
         :param membership_protocol: The group membership protocol to which this consumer
             should adhere
         :type membership_protocol: :class:`pykafka.membershipprotocol.GroupMembershipProtocol`
+        :param deserializer: A function defining how to deserialize messages returned
+            from Kafka. A function with the signature d(value, partition_key) that
+            returns a tuple of (deserialized_value, deserialized_partition_key). The
+            arguments passed to this function are the bytes representations of a
+            message's value and partition key, and the returned data should be these
+            fields transformed according to the client code's serialization logic.
+            See `pykafka.utils.__init__` for stock implemtations.
+        :type deserializer: function
         """
 
         self._cluster = cluster
@@ -199,6 +208,7 @@ class ManagedBalancedConsumer(BalancedConsumer):
         self._membership_protocol = membership_protocol
         self._membership_protocol.metadata.topic_names = [self._topic.name]
         self._heartbeat_interval_ms = valid_int(heartbeat_interval_ms)
+        self._deserializer = deserializer
         if use_rdkafka is True:
             raise ImportError("use_rdkafka is not available for {}".format(
                 self.__class__.__name__))

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -155,6 +155,14 @@ class Producer(object):
             with kafka after __init__ is complete. If false, communication
             can be started with `start()`.
         :type auto_start: bool
+        :param serializer: A function defining how to serialize messages to be sent
+            to Kafka. A function with the signature d(value, partition_key) that
+            returns a tuple of (serialized_value, serialized_partition_key). The
+            arguments passed to this function are a message's value and partition key,
+            and the returned data should be these fields transformed according to the
+            client code's serialization logic.  See `pykafka.utils.__init__` for stock
+            implemtations.
+        :type serializer: function
         """
         self._cluster = cluster
         self._protocol_version = msg_protocol_version(cluster._broker_version)

--- a/pykafka/rdkafka/producer.py
+++ b/pykafka/rdkafka/producer.py
@@ -49,7 +49,8 @@ class RdKafkaProducer(Producer):
                  max_request_size=1000012,
                  sync=False,
                  delivery_reports=False,
-                 auto_start=True):
+                 auto_start=True,
+                 serializer=None):
         callargs = {k: v for k, v in vars().items()
                     if k not in ("self", "__class__")}
         self._broker_version = cluster._broker_version

--- a/pykafka/rdkafka/simple_consumer.py
+++ b/pykafka/rdkafka/simple_consumer.py
@@ -54,7 +54,8 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
                  reset_offset_on_start=False,
                  compacted_topic=False,
                  generation_id=-1,
-                 consumer_id=b''):
+                 consumer_id=b'',
+                 deserializer=None):
         callargs = {k: v for k, v in vars().items()
                          if k not in ("self", "__class__")}
         self._rdk_consumer = None

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -156,6 +156,14 @@ class SimpleConsumer(object):
         :param consumer_id: The identifying string to use for this consumer on group
             requests
         :type consumer_id: bytes
+        :param deserializer: A function defining how to deserialize messages returned
+            from Kafka. A function with the signature d(value, partition_key) that
+            returns a tuple of (deserialized_value, deserialized_partition_key). The
+            arguments passed to this function are the bytes representations of a
+            message's value and partition key, and the returned data should be these
+            fields transformed according to the client code's serialization logic.
+            See `pykafka.utils.__init__` for stock implemtations.
+        :type deserializer: function
         """
         self._running = False
         self._cluster = cluster

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -74,7 +74,8 @@ class SimpleConsumer(object):
                  reset_offset_on_start=False,
                  compacted_topic=False,
                  generation_id=-1,
-                 consumer_id=b''):
+                 consumer_id=b'',
+                 deserializer=None):
         """Create a SimpleConsumer.
 
         Settings and default values are taken from the Scala
@@ -187,6 +188,7 @@ class SimpleConsumer(object):
         self._generation_id = valid_int(generation_id, allow_zero=True,
                                         allow_negative=True)
         self._consumer_id = consumer_id
+        self._deserializer = deserializer
 
         # incremented for any message arrival from any partition
         # the initial value is 0 (no messages waiting)
@@ -468,6 +470,9 @@ class SimpleConsumer(object):
             if not self._slot_available.is_set():
                 self._slot_available.set()
 
+        if self._deserializer is not None:
+            ret.value, ret.partition_key = self._deserializer(ret.value,
+                                                              ret.partition_key)
         return ret
 
     def _auto_commit(self):

--- a/pykafka/utils/__init__.py
+++ b/pykafka/utils/__init__.py
@@ -29,6 +29,10 @@ class Serializable(object):
 
 
 def serialize_utf8(value, partition_key):
+    """A serializer accepting bytes or str arguments and returning utf-8 encoded bytes
+
+    Can be used as `pykafka.producer.Producer(serializer=serialize_utf8)`
+    """
     if value is not None and type(value) != bytes:
         # allow UnicodeError to be raised here if the encoding fails
         value = value.encode('utf-8')
@@ -38,6 +42,11 @@ def serialize_utf8(value, partition_key):
 
 
 def deserialize_utf8(value, partition_key):
+    """A deserializer accepting bytes arguments and returning utf-8 strings
+
+    Can be used as `pykafka.simpleconsumer.SimpleConsumer(deserializer=deserialize_utf8)`,
+    or similarly in other consumer classes
+    """
     # allow UnicodeError to be raised here if the decoding fails
     if value is not None:
         value = value.decode('utf-8')

--- a/pykafka/utils/__init__.py
+++ b/pykafka/utils/__init__.py
@@ -28,6 +28,24 @@ class Serializable(object):
         raise NotImplementedError()
 
 
+def serialize_utf8(value, partition_key):
+    if value is not None and type(value) != bytes:
+        # allow UnicodeError to be raised here if the encoding fails
+        value = value.encode('utf-8')
+    if partition_key is not None and type(partition_key) != bytes:
+        partition_key = partition_key.encode('utf-8')
+    return value, partition_key
+
+
+def deserialize_utf8(value, partition_key):
+    # allow UnicodeError to be raised here if the decoding fails
+    if value is not None:
+        value = value.decode('utf-8')
+    if partition_key is not None:
+        partition_key = partition_key.decode('utf-8')
+    return value, partition_key
+
+
 VERSIONS_CACHE = {}
 
 


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/pykafka/issues/405 by implementing support for user-defined serialization/deserialization logic in the producer and consumer. By default, this logic is turned off, and message payloads and partition keys are assumed to be bytestrings throughout the pipeline. When a serializer or a deserializer is provided by client code, it causes the message payload and partition keys to be transformed at the edges - immediately upon the call to `produce()`, or immediately before `consume()` returns. This pull request also implements a stock SerDe that makes pykafka's components compatible with UTF-8 strings, allowing users who'd prefer not to cast everything to `bytes` an easy alternative.