### PR TITLE
don't let sync producer hang when delivery report is not received

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -383,7 +383,7 @@ class Producer(object):
                 try:
                     reported_msg, exc = self.get_delivery_report(timeout=1)
                     break
-                except Empty:
+                except (Empty, ValueError):
                     continue
             if reported_msg is not msg:
                 raise ProduceFailureError("Delivery report not received after timeout")

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -383,8 +383,10 @@ class Producer(object):
                 try:
                     reported_msg, exc = self.get_delivery_report(timeout=1)
                     break
-                except (Empty, ValueError):
+                except Empty:
                     continue
+                except ValueError:
+                    raise ProduceFailureError("Error retrieving delivery report")
             if reported_msg is not msg:
                 raise ProduceFailureError("Delivery report not received after timeout")
             if exc is not None:

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -22,7 +22,8 @@ except ImportError:
 
 from pykafka import KafkaClient
 from pykafka.common import OffsetType
-from pykafka.exceptions import MessageSizeTooLarge, ProducerQueueFullError
+from pykafka.exceptions import (MessageSizeTooLarge, ProducerQueueFullError,
+                                ProduceFailureError)
 from pykafka.partitioners import hashing_partitioner
 from pykafka.protocol import Message
 from pykafka.test.utils import get_cluster, stop_cluster, retry
@@ -101,6 +102,16 @@ class ProducerIntegrationTests(unittest2.TestCase):
             p._send_request = types.MethodType(stub_send_request, p)
             with self.assertRaises(ZeroDivisionError):
                 p.produce(b"test")
+
+    def test_sync_produce_doesnt_hang(self):
+        producer = self._get_producer(sync=True)
+
+        def stub_mark(w, x, y, z):
+            return None
+        # simulate delivery report being lost
+        producer._mark_as_delivered = types.MethodType(stub_mark, producer)
+        with self.assertRaises(ProduceFailureError):
+            producer.produce(b"test")
 
     def test_produce_hashing_partitioner(self):
         # unique bytes, just to be absolutely sure we're not fetching data

--- a/tests/pykafka/test_producer.py
+++ b/tests/pykafka/test_producer.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import mock
 import os
 import platform
 import pytest
@@ -110,6 +111,7 @@ class ProducerIntegrationTests(unittest2.TestCase):
             return None
         # simulate delivery report being lost
         producer._mark_as_delivered = types.MethodType(stub_mark, producer)
+        producer._delivery_reports = mock.MagicMock()
         with self.assertRaises(ProduceFailureError):
             producer.produce(b"test")
 


### PR DESCRIPTION
This pull request fixes the long-lived #449 by adding a `pending_timeout_ms` kwarg to the `Producer`. This kwarg indicates the amount of time that should be spent waiting for delivery reports / delivery marks before returning from calls that wait on them. This allows the producer to handle the case in which the delivery report is never received, possibly due to poor connection between broker and client. This PR also adds a test to exercise this use case.