### PR TITLE
deprecate SimpleConsumer(consumer_id)

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -426,7 +426,7 @@ class BalancedConsumer(object):
             reset_offset_on_start = False
         Cls = (rdkafka.RdKafkaSimpleConsumer
                if self._use_rdkafka else SimpleConsumer)
-        return Cls(
+        cns = Cls(
             self._topic,
             self._cluster,
             consumer_group=self._consumer_group,
@@ -446,9 +446,10 @@ class BalancedConsumer(object):
             auto_start=start,
             compacted_topic=self._is_compacted_topic,
             generation_id=self._generation_id,
-            consumer_id=self._consumer_id,
             deserializer=self._deserializer
         )
+        cns.consumer_id = self._consumer_id
+        return cns
 
     def _get_participants(self):
         """Use zookeeper to get the other consumers of this topic.

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -445,10 +445,10 @@ class BalancedConsumer(object):
             reset_offset_on_start=reset_offset_on_start,
             auto_start=False,
             compacted_topic=self._is_compacted_topic,
-            generation_id=self._generation_id,
             deserializer=self._deserializer
         )
         cns.consumer_id = self._consumer_id
+        cns.generation_id = self._generation_id
         if start:
             cns.start()
         return cns

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -376,13 +376,13 @@ class BalancedConsumer(object):
         self._zookeeper = KazooClient(zookeeper_connect, **kazoo_kwargs)
         self._zookeeper.start()
 
-    def _setup_internal_consumer(self, partitions=None):
+    def _setup_internal_consumer(self, partitions=None, start=True):
         """Instantiate an internal SimpleConsumer instance"""
         if partitions is None:
             partitions = []
         # Only re-create internal consumer if something changed.
         if partitions != self._partitions:
-            cns = self._get_internal_consumer(partitions=list(partitions))
+            cns = self._get_internal_consumer(partitions=list(partitions), start=start)
             if self._post_rebalance_callback is not None:
                 old_offsets = (self._consumer.held_offsets
                                if self._consumer else dict())
@@ -408,7 +408,7 @@ class BalancedConsumer(object):
                 self._internal_consumer_running.clear()
         return True
 
-    def _get_internal_consumer(self, partitions=None):
+    def _get_internal_consumer(self, partitions=None, start=True):
         """Instantiate a SimpleConsumer for internal use.
 
         If there is already a SimpleConsumer instance held by this object,
@@ -449,7 +449,8 @@ class BalancedConsumer(object):
             deserializer=self._deserializer
         )
         cns.consumer_id = self._consumer_id
-        cns.start()
+        if start:
+            cns.start()
         return cns
 
     def _get_participants(self):

--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -376,13 +376,13 @@ class BalancedConsumer(object):
         self._zookeeper = KazooClient(zookeeper_connect, **kazoo_kwargs)
         self._zookeeper.start()
 
-    def _setup_internal_consumer(self, partitions=None, start=True):
+    def _setup_internal_consumer(self, partitions=None):
         """Instantiate an internal SimpleConsumer instance"""
         if partitions is None:
             partitions = []
         # Only re-create internal consumer if something changed.
         if partitions != self._partitions:
-            cns = self._get_internal_consumer(partitions=list(partitions), start=start)
+            cns = self._get_internal_consumer(partitions=list(partitions))
             if self._post_rebalance_callback is not None:
                 old_offsets = (self._consumer.held_offsets
                                if self._consumer else dict())
@@ -408,7 +408,7 @@ class BalancedConsumer(object):
                 self._internal_consumer_running.clear()
         return True
 
-    def _get_internal_consumer(self, partitions=None, start=True):
+    def _get_internal_consumer(self, partitions=None):
         """Instantiate a SimpleConsumer for internal use.
 
         If there is already a SimpleConsumer instance held by this object,
@@ -443,12 +443,13 @@ class BalancedConsumer(object):
             offsets_commit_max_retries=self._offsets_commit_max_retries,
             auto_offset_reset=self._auto_offset_reset,
             reset_offset_on_start=reset_offset_on_start,
-            auto_start=start,
+            auto_start=False,
             compacted_topic=self._is_compacted_topic,
             generation_id=self._generation_id,
             deserializer=self._deserializer
         )
         cns.consumer_id = self._consumer_id
+        cns.start()
         return cns
 
     def _get_participants(self):

--- a/pykafka/exceptions.py
+++ b/pykafka/exceptions.py
@@ -212,7 +212,8 @@ class InconsistentGroupProtocol(ProtocolClientError):
 
 class UnknownMemberId(ProtocolClientError):
     """Returned from group requests (offset commits/fetches, heartbeats, etc) when the
-        memberId is not in the current generation.
+        memberId is not in the current generation. Also returned if SimpleConsumer is
+        incorrectly instantiated with a non-default consumer_id.
     """
     ERROR_CODE = 25
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -195,8 +195,7 @@ class SimpleConsumer(object):
         self._auto_start = auto_start
         self._reset_offset_on_start = reset_offset_on_start
         self._is_compacted_topic = compacted_topic
-        self._generation_id = valid_int(generation_id, allow_zero=True,
-                                        allow_negative=True)
+        self._generation_id = 0
         self._consumer_id = b''
         self._deserializer = deserializer
 
@@ -253,7 +252,8 @@ class SimpleConsumer(object):
 
     @generation_id.setter
     def generation_id(self, value):
-        self._generation_id = value
+        self._generation_id = valid_int(value, allow_zero=True,
+                                        allow_negative=True)
 
     def __repr__(self):
         return "<{module}.{name} at {id_} (consumer_group={group})>".format(

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -864,6 +864,7 @@ class OwnedPartition(object):
         self.last_offset_consumed = -1
         self.next_offset = 0
         self.fetch_lock = handler.RLock() if handler is not None else threading.RLock()
+        self.set_consumer_id(self._consumer_id)
 
     def set_consumer_id(self, value):
         self._consumer_id = value

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -247,6 +247,14 @@ class SimpleConsumer(object):
         for op in itervalues(self._partitions):
             op.set_consumer_id(self._consumer_id)
 
+    @property
+    def generation_id(self):
+        return self._generation_id
+
+    @generation_id.setter
+    def generation_id(self, value):
+        self._generation_id = value
+
     def __repr__(self):
         return "<{module}.{name} at {id_} (consumer_group={group})>".format(
             module=self.__class__.__module__,

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -151,10 +151,12 @@ class SimpleConsumer(object):
             consumer to use less stringent message ordering logic because compacted
             topics do not provide offsets in strict incrementing order.
         :type compacted_topic: bool
-        :param generation_id: The generation id with which to make group requests
+        :param generation_id: Deprecated::2.7 Do not set if directly instantiating
+            SimpleConsumer. The generation id with which to make group requests
         :type generation_id: int
-        :param consumer_id: The identifying string to use for this consumer on group
-            requests
+        :param consumer_id: Deprecated::2.7 Do not set if directly instantiating
+            SimpleConsumer. The identifying string to use for this consumer on
+            group requests
         :type consumer_id: bytes
         :param deserializer: A function defining how to deserialize messages returned
             from Kafka. A function with the signature d(value, partition_key) that

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -195,7 +195,7 @@ class SimpleConsumer(object):
         self._auto_start = auto_start
         self._reset_offset_on_start = reset_offset_on_start
         self._is_compacted_topic = compacted_topic
-        self._generation_id = 0
+        self._generation_id = -1
         self._consumer_id = b''
         self._deserializer = deserializer
 


### PR DESCRIPTION
This pull request builds on @bootandy's contributions in https://github.com/Parsely/pykafka/pull/631 to deprecate the `consumer_id` kwarg on `SimpleConsumer.__init__`. It accomplishes this by making this parameter settable outside of `__init__` and doing so in `BalancedConsumer`. 