### PR TITLE
catch nonodeerror when relinquishing partition

### DIFF
--- a/pykafka/balancedconsumer.py
+++ b/pykafka/balancedconsumer.py
@@ -617,8 +617,11 @@ class BalancedConsumer(object):
         :type partitions: Iterable of :class:`pykafka.partition.Partition`
         """
         for p in partitions:
-            # TODO pass zk node version to make sure we still own this node
-            self._zookeeper.delete(self._path_from_partition(p))
+            try:
+                # TODO pass zk node version to make sure we still own this node
+                self._zookeeper.delete(self._path_from_partition(p))
+            except NoNodeException:
+                pass
 
     def _add_partitions(self, partitions):
         """Add partitions to the zookeeper registry for this consumer.


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/pykafka/issues/761 by making the `BalancedConsumer` resilient to missing zookeeper partition nodes that it attempts to relinquish control of.