### PR TITLE
retrying broker connection

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -234,7 +234,7 @@ class Broker(object):
         """
         return self._offsets_channel_req_handler
 
-    def connect(self):
+    def connect(self, attempts=3):
         """Establish a connection to the broker server.
 
         Creates a new :class:`pykafka.connection.BrokerConnection` and a new
@@ -246,11 +246,11 @@ class Broker(object):
                                             source_host=self._source_host,
                                             source_port=self._source_port,
                                             ssl_config=self._ssl_config)
-        self._connection.connect(self._socket_timeout_ms)
+        self._connection.connect(self._socket_timeout_ms, attempts=attempts)
         self._req_handler = RequestHandler(self._handler, self._connection)
         self._req_handler.start()
 
-    def connect_offsets_channel(self):
+    def connect_offsets_channel(self, attempts=3):
         """Establish a connection to the Broker for the offsets channel
 
         Creates a new :class:`pykafka.connection.BrokerConnection` and a new
@@ -262,7 +262,8 @@ class Broker(object):
             buffer_size=self._buffer_size,
             source_host=self._source_host, source_port=self._source_port,
             ssl_config=self._ssl_config)
-        self._offsets_channel_connection.connect(self._offsets_channel_socket_timeout_ms)
+        self._offsets_channel_connection.connect(self._offsets_channel_socket_timeout_ms,
+                                                 attempts=attempts)
         self._offsets_channel_req_handler = RequestHandler(
             self._handler, self._offsets_channel_connection
         )

--- a/pykafka/connection.py
+++ b/pykafka/connection.py
@@ -176,8 +176,9 @@ class BrokerConnection(object):
             except (self._handler.SockErr, self._handler.GaiError) as err:
                 log.info("Attempt %s: failed to connect to %s:%s", attempt, self.host, self.port)
                 log.info(err)
-                log.info("Retrying in 300ms.")
-                time.sleep(.3)
+                if attempts > 1:
+                    log.info("Retrying in 300ms.")
+                    time.sleep(.3)
                 continue
 
         raise SocketDisconnectedError("<broker {}:{}>".format(self.host, self.port))

--- a/tests/pykafka/test_connection.py
+++ b/tests/pykafka/test_connection.py
@@ -1,8 +1,11 @@
 import unittest
 import threading
 import time
+import pytest
 
 from uuid import uuid4
+
+from testinstances.managed_instance import ManagedInstance
 
 from pykafka import KafkaClient, Broker
 from pykafka.connection import BrokerConnection
@@ -16,6 +19,8 @@ class TestBrokerConnection(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kafka = get_cluster()
+        if not isinstance(cls.kafka, ManagedInstance):
+            pytest.skip("Only test on ManagedInstance (run locally)")
         cls.client = KafkaClient(cls.kafka.brokers)
 
         # BrokerConnection

--- a/tests/pykafka/test_connection.py
+++ b/tests/pykafka/test_connection.py
@@ -1,0 +1,64 @@
+import unittest
+import threading
+import time
+
+from uuid import uuid4
+
+from pykafka import KafkaClient, Broker
+from pykafka.connection import BrokerConnection
+from pykafka.exceptions import SocketDisconnectedError
+from pykafka.handlers import ThreadingHandler
+from pykafka.utils.compat import itervalues
+from pykafka.test.utils import get_cluster, stop_cluster
+
+
+class TestBrokerConnection(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kafka = get_cluster()
+        cls.client = KafkaClient(cls.kafka.brokers)
+
+        # BrokerConnection
+        ports = cls.kafka._port_generator(9092)
+        cls.dest_port = next(ports)
+        cls.src_port = next(ports)
+        cls.conn = BrokerConnection('localhost',
+                                 cls.dest_port,
+                                 cls.client._handler,
+                                 buffer_size=1024 * 1024,
+                                 source_host='localhost',
+                                 source_port=cls.src_port,
+                                 ssl_config=None)
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_cluster(cls.kafka)
+
+    def test_connection_fails_no_broker(self):
+        """Fail connection when no broker proc exists"""
+        assert self.conn is not None
+        with self.assertRaises(SocketDisconnectedError):
+            self.conn.connect(3 * 1000)
+
+    def test_retry_connect(self):
+        """Should retry until the connection succeeds."""
+        def delayed_make_broker():
+            time.sleep(2)
+            self.kafka._start_broker_proc(self.dest_port)
+
+        def retry_connect_broker():
+            self.conn.connect(3 * 1000, attempts=20)
+
+        # start broker after delay to ensure initial failure
+        delay_make_broker_thread = threading.Thread(target=delayed_make_broker)
+        delay_make_broker_thread.start()
+
+        # connect to broker, using retry
+        connect_broker_thread = threading.Thread(target=retry_connect_broker)
+        connect_broker_thread.start()
+
+        # give enough time for broker creation to complete
+        delay_make_broker_thread.join(5)
+        connect_broker_thread.join(6)
+
+        assert self.conn.connected is True


### PR DESCRIPTION
API changes: 
minor change to `BrokerConnection` and `Broker`, (optional kwarg)
internal change to `Broker` class, within __init__ uses `attempts=3` to give 3 retries upon first usage of the class.


New Functionality:
`BrokerConnection` can now retry making the connection. The new default is 3 attempts, which applies both for new `Broker` creation (it calls `connect()` on initialization) and for public methods on a `Broker` instance. 

This change is meant to prevent ephemeral networking errors or timeouts from stopping a consumer entirely. It will wait 300ms between attempts.

Misc
 - split out a function in the KafkaInstance class to create a new broker proc.