### PR TITLE
Fix issues with NoneType when shutting down

### DIFF
--- a/pykafka/handlers.py
+++ b/pykafka/handlers.py
@@ -186,9 +186,11 @@ class RequestHandler(object):
         """Stop the request processor."""
         shared = self.shared
         self.shared = None
-        log.info("RequestHandler.stop: about to flush requests queue")
-        shared.requests.join()
-        shared.ending.set()
+        if log:
+            log.info("RequestHandler.stop: about to flush requests queue")
+        if shared:
+            shared.requests.join()
+            shared.ending.set()
 
     def _start_thread(self):
         """Run the request processor"""


### PR DESCRIPTION
When shutting things down I kept seeing the following error

```
Exception AttributeError: "'NoneType' object has no attribute 'info'" in <bound method RequestHandler.__del__ of <pykafka.handlers.RequestHandler object at 0x7fc2cef26c10>> ignored
```

It is not clear to me why the error happens or why `log` and `shared` could ever be none but this fixes the problem.