### PR TITLE
stop/start the linger/flush cycle based on queue emptiness

### DIFF
--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -741,7 +741,10 @@ class OwnedBroker(object):
             if timeout_ms != -1:
                 self.has_message.wait(timeout_ms / 1000)
             else:
-                self.has_message.wait()
+                # inifinite wait that doesn't break under gevent
+                while not self.has_message.is_set():
+                    self.producer._cluster.handler.sleep()
+                    self.has_message.wait(5)
 
     def _wait_for_slot_available(self):
         """Block until the queue has at least one slot not containing a message"""

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -769,7 +769,7 @@ class OwnedBroker(object):
             if timeout_ms != -1:
                 self.has_message.wait(timeout_ms / 1000)
             else:
-                # inifinite wait that doesn't break under gevent
+                # infinite wait that doesn't break under gevent
                 while not self.has_message.is_set():
                     self.producer._cluster.handler.sleep()
                     self.has_message.wait(5)

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -71,6 +71,8 @@ class Producer(object):
                  max_queued_messages=100000,
                  min_queued_messages=70000,
                  linger_ms=5 * 1000,
+                 # XXX 0 default here mirrors previous behavior - should default have a
+                 # nonzero wait to save CPU cycles?
                  queue_empty_timeout_ms=0,
                  block_on_queue_full=True,
                  max_request_size=1000012,

--- a/pykafka/producer.py
+++ b/pykafka/producer.py
@@ -71,7 +71,7 @@ class Producer(object):
                  max_queued_messages=100000,
                  min_queued_messages=70000,
                  linger_ms=5 * 1000,
-                 queue_empty_timeout_ms=5 * 1000,
+                 queue_empty_timeout_ms=0,
                  block_on_queue_full=True,
                  max_request_size=1000012,
                  sync=False,


### PR DESCRIPTION
If the queue is empty after linger_ms of waiting, wait until there is at least one message in the queue to start lingering again, or until a configurable timeout. The default behavior mirrors current master.

Fixes #788