### PR TITLE
only add brokers to replicas set that the cluster is aware of

### DIFF
--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -229,7 +229,10 @@ class Topic(object):
                 self._partitions[meta.id] = Partition(
                     self, meta.id,
                     brokers[meta.leader],
-                    [brokers[b] for b in meta.replicas],
+                    # only add replicas that the cluster is aware of to avoid
+                    # KeyErrors here. inconsistencies will be automatically
+                    # resolved when `Cluster.update` is called.
+                    [brokers[b] for b in meta.replicas if b in brokers],
                     [brokers[b] for b in meta.isr],
                 )
             else:


### PR DESCRIPTION
This pull request attempts to fix #797 by dodging the `KeyError` described therein. This change is theoretically safe because any inconsistencies between the actual state of the cluster and the `Topic` instance's representation of it will be resolved by the calls to `Cluster.update` triggered by ZK watches in the producer and consumer.