### PR TITLE
improve logging and retry logic when broker is unreachable

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -120,8 +120,9 @@ class Broker(object):
         try:
             self.connect()
         except SocketDisconnectedError:
-            log.warning("Failed to connect newly created broker for {host}:{port}".format(
-                host=self._host, port=self._port))
+            log.warning("Failed to connect to broker at {host}:{port}. Check the "
+                        "`listeners` property in server.config."
+                        .format(host=self._host, port=self._port))
 
     def __repr__(self):
         return "<{module}.{name} at {id_} (host={host}, port={port}, id={my_id})>".format(


### PR DESCRIPTION
This pull request fixes #758 by improving logging and retry logic in `Cluster.get_group_coordinator` when a broker has not been successfully connected. There is already some logging in `broker.py` to this effect, but since that information doesn't appear in the traceback, it's getting buried in bug reports.