### PR TITLE
update kazoo / gevent dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,12 @@ def get_version():
 
 install_requires = [
     'six>=1.5',
-    'kazoo',
+    'kazoo==2.5.0',
     'tabulate'
 ]
 
 extra_gevent_requires = [
-    'gevent>=1.2.2,<1.3'
+    'gevent==1.3'
 ]
 
 extra_requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27, py34, py35, py36, pypy, {py27,py36}-gevent
 usedevelop = True
 deps =
     -rtest-requirements.txt
-    gevent: gevent==1.2.2
+    gevent: gevent==1.3
 commands =
     py.test {posargs}
 passenv = BROKERS BROKERS_SSL ZOOKEEPER KAFKA_BIN KAFKA_VERSION C_INCLUDE_PATH LIBRARY_PATH LD_LIBRARY_PATH CFLAGS


### PR DESCRIPTION
Now that kazoo 2.5.0 is released, we can update our gevent dependency.

Related to https://github.com/Parsely/pykafka/issues/801