### PR TITLE
call cleanup() in fetch instead of autocommitter

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -421,7 +421,6 @@ class SimpleConsumer(object):
                     # surface all exceptions to the main thread
                     self._worker_exception = sys.exc_info()
                     break
-            self.cleanup()
             log.debug("Autocommitter thread exiting")
         log.debug("Starting autocommitter thread")
         return self._cluster.handler.spawn(autocommitter, name="pykafka.SimpleConsumer.autocommiter")
@@ -444,6 +443,11 @@ class SimpleConsumer(object):
                     # surface all exceptions to the main thread
                     self._worker_exception = sys.exc_info()
                     break
+            try:
+                self.cleanup()
+            except ReferenceError as e:
+                log.debug("Attempt to cleanup consumer failed")
+                log.exception(e)
             log.debug("Fetcher thread exiting")
         log.info("Starting %s fetcher threads", self._num_consumer_fetchers)
         return [self._cluster.handler.spawn(fetcher, name="pykafka.SimpleConsumer.fetcher")


### PR DESCRIPTION
This pull request addresses #823 by moving the call to `cleanup()` from the `SimpleConsumer`'s autocommitter thread to its fetcher thread. This ensures that `cleanup` is called even when `auto_commit_enable=False`. The call is also wrapped in a `ReferenceError` check to avoid the issue mentioned in #823.