### PR TITLE
Standardize offsets_before argument

### DIFF
--- a/pykafka/common.py
+++ b/pykafka/common.py
@@ -18,10 +18,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 __all__ = ["Message", "CompressionType", "OffsetType"]
+import datetime as dt
 import logging
 
 
 log = logging.getLogger(__name__)
+EPOCH = dt.datetime(1970, 1, 1)
 
 
 class Message(object):

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -95,12 +95,14 @@ class Partition(object):
         """Use the Offset API to find a limit of valid offsets
             for this partition.
 
-        :param offsets_before: Return an offset from before this timestamp (in
-            milliseconds)
-        :type offsets_before: int
+        :param offsets_before: Return an offset from before
+            this timestamp (in milliseconds). Deprecated::2.7,3.6: do not use int
+        :type offsets_before: `datetime.datetime` or int
         :param max_offsets: The maximum number of offsets to return
         :type max_offsets: int
         """
+        if isinstance(offsets_before, dt.datetime):
+            offsets_before = round((offsets_before - EPOCH).total_seconds() * 1000)
         for i in range(self.topic._cluster._max_connection_retries):
             if i > 0:
                 log.debug("Retrying offset limit fetch")

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -17,11 +17,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 __all__ = ["Partition"]
+import datetime as dt
 import logging
 import time
 import weakref
 
-from .common import OffsetType
+from .common import OffsetType, EPOCH
 from .exceptions import LeaderNotFoundError
 from .protocol import PartitionOffsetRequest
 

--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -31,7 +31,7 @@ import weakref
 
 from six import reraise
 
-from .common import OffsetType
+from .common import OffsetType, EPOCH
 from .utils.compat import (Queue, Empty, iteritems, itervalues,
                            range, iterkeys, get_bytes, get_string)
 from .exceptions import (UnknownError, OffsetOutOfRangeError, UnknownTopicOrPartition,
@@ -48,7 +48,6 @@ from .utils.error_handlers import (handle_partition_responses, raise_error,
 
 
 log = logging.getLogger(__name__)
-EPOCH = dt.datetime(1970, 1, 1)
 MAGIC_OFFSETS = [OffsetType.EARLIEST, OffsetType.LATEST]
 
 


### PR DESCRIPTION
This pull request fixes https://github.com/Parsely/pykafka/issues/833 by allowing `Topic.fetch_offset_limits` and `Partition.fetch_offset_limit` to have their `offsets_before` argument specified as a programmer-friendly datetime in addition to a raw integer unix timestamp. It also deprecates the argument as an integer for the next major version release. 