### PR TITLE
Prevent attempts to reset the offset when trying to fetch consumer lag.

### DIFF
--- a/pykafka/cli/kafka_tools.py
+++ b/pykafka/cli/kafka_tools.py
@@ -54,7 +54,8 @@ def fetch_consumer_lag(client, topic, consumer_group):
     """
     latest_offsets = fetch_offsets(client, topic, 'latest')
     consumer = topic.get_simple_consumer(consumer_group=consumer_group,
-                                         auto_start=False)
+                                         auto_start=False, 
+                                         reset_offset_on_fetch=False)
     current_offsets = consumer.fetch_offsets()
     return {p_id: (latest_offsets[p_id].offset[0], res.offset)
             for p_id, res in current_offsets}


### PR DESCRIPTION
`kafka_tools.fetch_consumer_lag` will attempt to reset the offset for a consumer group that does not have any offsets for a topic. This is unexpected behavior, since it seems to indicate it will just read data. Additionally, if the reset fails, it can cause a timeout for the calling service (since consumer_timeout_ms is not set), which can be a problem for monitoring tools.