### PR TITLE
descriptive error message for buffer decode failures

### DIFF
--- a/pykafka/simpleconsumer.py
+++ b/pykafka/simpleconsumer.py
@@ -812,6 +812,10 @@ class SimpleConsumer(object):
                     # If the broker dies while we're supposed to stop,
                     # it's fine, and probably an integration test.
                     return
+                except socket.error:
+                    raise ValueError("Failed to decode IO buffer. Ensure that "
+                                     "the KafkaClient's broker_version kwarg "
+                                     "matches the version of the Kafka cluster.")
                 parts_by_error = build_parts_by_error(response, self._partitions_by_id)
                 handle_partition_responses(
                     self._default_error_handlers,


### PR DESCRIPTION
This pull request fixes #598 by making the error message more helpful in cases where the IO buffer failed to decode, since this can often happen on older clusters when there's a mismatch between cluster version and the `KafkaClient`'s `broker_version` kwarg.