### PR TITLE
implement __contains__ on TopicDict 

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -54,6 +54,13 @@ class TopicDict(dict):
     def values(self):
         return [self[key] for key in self]
 
+    def __contains__(self, key):
+        try:
+            key = get_string(key).encode('ascii')
+        except UnicodeEncodeError:
+            return False
+        return super(TopicDict, self).__contains__(key)
+
     def __getitem__(self, key):
         try:
             key = get_string(key).encode('ascii')


### PR DESCRIPTION
This pull request fixes a bug on `TopicDict` causing `__contains__` to function differently from `__getattr__`. In python3, the following was possible before this fix:
```python
In [1]: from pykafka import KafkaClient                                               
                                                                                                                  
In [2]: client = KafkaClient(hosts="localhost:9092")
                                                            
In [3]: client.topics['testtopic_replicated']                              
Out[3]: <pykafka.topic.Topic at 0x7f81bde9ffd0 (name=b'testtopic_replicated')>
                                      
In [4]: 'testtopic_replicated' in client.topics                      
Out[4]: False                                                    
```
Using the same string with the `in` operator and during direct attribute access yielded different results. This pull request fixes that issue by performing the same string conversion in `__contains__` that's performed in `__getattr__`.