### PR TITLE
Fix tests for librdkafka 0.11.3+

### DIFF
--- a/pykafka/rdkafka/simple_consumer.py
+++ b/pykafka/rdkafka/simple_consumer.py
@@ -248,9 +248,10 @@ class RdKafkaSimpleConsumer(SimpleConsumer):
             # queued.max.messages.kbytes so for now we infer the implied
             # maximum (which, with default settings, is ~2GB per partition):
             "queued.min.messages": self._queued_max_messages,
-            "queued.max.messages.kbytes": str(
+            "queued.max.messages.kbytes": str(min(
                 self._queued_max_messages
-                * self._fetch_message_max_bytes // 1024),
+                * self._fetch_message_max_bytes // 1024,
+                2097151)),  # queued.max.messages.kbytes is 1..2097151 according to librdkafka cc43f4
 
             "fetch.wait.max.ms": self._fetch_wait_max_ms,
             "fetch.message.max.bytes": self._fetch_message_max_bytes,


### PR DESCRIPTION
Limit queued.max.messages.kbytes according to librdkafka cc43f4.

This will fix rdkafka tests on librdkafka 0.11.3+.
```
E       RdKafkaException: Configuration property "queued.max.messages.kbytes" value 102400000 is outside allowed range 1..2097151
```