### PR TITLE
Use env var to explicitly specify rdkafka setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,8 +159,16 @@ Using the librdkafka extension
 ------------------------------
 
 PyKafka includes a C extension that makes use of librdkafka to speed up producer
-and consumer operation. PyKafka requires librdkafka v0.9.1+. Some system package managers may 
-not have up-to-date versions. To use the librdkafka extension, you need to make sure the header
+and consumer operation.
+
+To ensure the C extension is compiled, set environment variable ``RDKAFKA_INSTALL=system`` during
+``pip install`` or ``setup.py``, i.e. ``RDKAFKA_INSTALL=system pip install pykafka``.
+The setup will fail if C extension is not compiled. Oppositely, if ``RDKAFKA_INSTALL=''``, this
+explicitly specifies that the C extension should not be compiled. The current default behavior is
+to compile the extension but will not fail the setup if compilation fails.
+
+PyKafka requires librdkafka v0.9.1+. Some system package managers may not have
+up-to-date versions. To use the librdkafka extension, you need to make sure the header
 files and shared library are somewhere where python can find them, both when you build
 the extension (which is taken care of by ``setup.py develop``) and at run time.
 Typically, this means that you need to either install librdkafka in a place

--- a/setup.py
+++ b/setup.py
@@ -188,13 +188,13 @@ def run_setup(with_rdkafka=True):
 # Use environment variable RDKAFKA_INSTALL to explicitly specify whether rdkafka c extension should be compiled
 # 'system': Compile with librdkafka installed in system
 # '' (empty string): No compile
-install_type = os.environ.get('RDKAFKA_INSTALL')
+rdkafka_install_type = os.environ.get('RDKAFKA_INSTALL')
 
 try:
-    if install_type == '':
+    if rdkafka_install_type == '':
         run_setup(with_rdkafka=False)
     elif not is_cpython:
-        if install_type == 'system':
+        if rdkafka_install_type == 'system':
             raise Exception("librdkafka is not supported under %s, but RDKAFKA_INSTALL specified"
                             % python_implementation)
         print("librdkafka is not supported under %s" % python_implementation)
@@ -204,9 +204,9 @@ try:
         print(15 * "-")
         run_setup(with_rdkafka=False)
     else:
-        run_setup()  # Try to compile c ext for cpython by default
+        run_setup()
 except ve_build_ext.BuildFailed as exc:
-    if install_type == 'system':
+    if rdkafka_install_type == 'system':
         raise
     print(15 * "-")
     print("INFO: Failed to build rdkafka extension:")

--- a/setup.py
+++ b/setup.py
@@ -184,8 +184,19 @@ def run_setup(with_rdkafka=True):
         ]
     )
 
+
+# Use environment variable RDKAFKA_INSTALL to explicitly specify whether rdkafka c extension should be compiled
+# 'system': Compile with librdkafka installed in system
+# '' (empty string): No compile
+install_type = os.environ.get('RDKAFKA_INSTALL')
+
 try:
-    if not is_cpython:
+    if install_type == '':
+        run_setup(with_rdkafka=False)
+    elif not is_cpython:
+        if install_type == 'system':
+            raise Exception("librdkafka is not supported under %s, but RDKAFKA_INSTALL specified"
+                            % python_implementation)
         print("librdkafka is not supported under %s" % python_implementation)
         print(15 * "-")
         print("INFO: Failed to build rdkafka extension:")
@@ -193,8 +204,10 @@ try:
         print(15 * "-")
         run_setup(with_rdkafka=False)
     else:
-        run_setup()
+        run_setup()  # Try to compile c ext for cpython by default
 except ve_build_ext.BuildFailed as exc:
+    if install_type == 'system':
+        raise
     print(15 * "-")
     print("INFO: Failed to build rdkafka extension:")
     print(exc.cause)


### PR DESCRIPTION
Read RDKAFKA_INSTALL env var on setup.
When RDKAFKA_INSTALL='system', compile rdkafka c ext. Fail setup on
compilation error.
When RDKAFKA_INSTALL='', don't compile rdkafka c ext.

No change on default behavior when RDKAFKA_INSTALL is not specified /
invalid value.

Fix #920