### PR TITLE
Improve stability in cases of new broker additions to cluster

### DIFF
--- a/pykafka/cluster.py
+++ b/pykafka/cluster.py
@@ -83,6 +83,10 @@ class TopicDict(dict):
                     log.warning("LeaderNotFoundError encountered during Topic creation")
                     if i == self._cluster()._max_connection_retries - 1:
                         raise
+
+                    # A partition's leader is not present in our cluster's brokers list.
+                    # Refresh the cluster metadata & retry
+                    self._cluster().update()
                 else:
                     self[key] = weakref.ref(topic)
                     return topic

--- a/pykafka/partition.py
+++ b/pykafka/partition.py
@@ -48,7 +48,7 @@ class Partition(object):
         :param replicas: A list of brokers containing this partition's replicas
         :type replicas: Iterable of :class:`pykafka.broker.Broker`
         :param isr: The current set of in-sync replicas for this partition
-        :type isr: :class:`pykafka.broker.Broker`
+        :type isr: Iterable of :class:`pykafka.broker.Broker`
         """
         self._id = id_
         self._leader = leader

--- a/pykafka/topic.py
+++ b/pykafka/topic.py
@@ -237,7 +237,7 @@ class Topic(object):
                     # KeyErrors here. inconsistencies will be automatically
                     # resolved when `Cluster.update` is called.
                     [brokers[b] for b in meta.replicas if b in brokers],
-                    [brokers[b] for b in meta.isr],
+                    [brokers[b] for b in meta.isr if b in brokers],
                 )
             else:
                 self._partitions[id_].update(brokers, meta)


### PR DESCRIPTION
- Handle topic creation when a partition has in-sync replicas that current broker configuration doesn't know
- Update cluster's metadata when a partition's leader is not listed in currently known brokers 