### PR TITLE
Socket reconnection on retries of JoinGroup, SyncGroup, LeaveGroup

### DIFF
--- a/pykafka/managedbalancedconsumer.py
+++ b/pykafka/managedbalancedconsumer.py
@@ -324,10 +324,10 @@ class ManagedBalancedConsumer(BalancedConsumer):
                 log.debug("Successfully rebalanced consumer '%s'", self._consumer_id)
                 break
             except Exception as ex:
+                log.exception(ex)
                 if i == self._rebalance_max_retries - 1:
                     log.warning('Failed to rebalance s after %d retries.', i)
                     raise
-                log.exception(ex)
                 log.info('Unable to complete rebalancing. Retrying')
                 self._cluster.handler.sleep(i * (self._rebalance_backoff_ms / 1000))
         self._raise_worker_exceptions()


### PR DESCRIPTION
Today, if `JoinGroup` sees a socket disconnection, it will retry again without reconnecting the connection which results in subsequent retries all to fail.

This change will ensure that we attempt to reconnect the connection if see a disconnected connection while selecting a unique `RequestHandler` to use for this request.

Alternative approaches that can be considered:

- Reconnect automatically in `RequestHandler.request` before calling `self.shared.requests.put`
- Reconnect automatically in `BrokerConnection.request` if required