### PR TITLE
Include tests in the sdsit but don't install them

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.txt
 include LICENSE
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ def run_setup(with_rdkafka=True):
         long_description=readme,
         keywords='apache kafka client driver',
         license='Apache License 2.0',
-        packages=find_packages(),
+        packages=find_packages(exclude=["tests", "tests.*"]),
         entry_points={
             'console_scripts': [
                 'kafka-tools = pykafka.cli.kafka_tools:main',


### PR DESCRIPTION
By adding the test folder to the manifest but excluding them on `find_packages`, they will be part of the `sdist`, allowing repackaging tools to run the tests but they won't be installed when a user pip installs this package.
This is to prevent the creation of a `tests` module in the user installation.

To verify: install the package in a virtualenv and check the contents of `site_packages/tests`, it should be not existing after this PR.

Let me know if you want me to create an issue for this.