### PR TITLE
Use functools to mark the _check_handler decorator as a wrapper

### DIFF
--- a/pykafka/broker.py
+++ b/pykafka/broker.py
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 __all__ = ["Broker"]
+import functools
 import logging
 import time
 
@@ -39,6 +40,7 @@ log = logging.getLogger(__name__)
 
 def _check_handler(fn):
     """Ensures that self._req_handler is not None before calling fn"""
+    @functools.wraps(fn)
     def wrapped(self, *args, **kwargs):
         if self._req_handler is None:
             raise SocketDisconnectedError


### PR DESCRIPTION
Using @functools.wrap ensures that docstrings for wrapped functions are passed through the decorator correctly.

Before:
```
$  pydoc pykafka.broker.Broker.create_topics
Help on function wrapped in pykafka.broker.Broker:

pykafka.broker.Broker.create_topics = wrapped(self, *args, **kwargs)
```

After:
```
$ pydoc pykafka.broker.Broker.create_topics

pykafka.broker.Broker.create_topics = create_topics(self, topic_reqs, timeout=0)
    Create topics via the Topic Creation API
    
    :param topic_reqs: The topic creation requests to issue
    :type topics: Iterable of :class:`pykafka.protocol.CreateTopicRequest`
    :param timeout: The time in ms to wait for a topic to be completely created.
        Values <= 0 will trigger topic creation and return immediately.
    :type timeout: int
```

I've also noticed that the wrapped topic API methods don't appear in the RTD documentation. This might fix that, but I'm not sure.
