### PR TITLE
Don't restrict Python dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,18 +39,18 @@ def get_version():
 
 install_requires = [
     'six>=1.5',
-    'kazoo==2.5.0',
+    'kazoo>=2.5.0',
     'tabulate'
 ]
 
 extra_gevent_requires = [
-    'gevent==1.3.6'
+    'gevent>=1.3.6'
 ]
 
 extra_requires = [
-    'lz4==0.10.1',
-    'lz4tools==1.3.1.2',
-    'xxhash==1.0.1'
+    'lz4>=0.10.1',
+    'lz4tools>=1.3.1.2',
+    'xxhash>=1.0.1'
 ] + extra_gevent_requires
 
 lint_requires = [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,10 @@
-lz4==2.1.10
-lz4tools==1.3.1.2
-pytest==4.6.2
+lz4>=2.1.10
+lz4tools>=1.3.1.2
+pytest>=4.6.2
 pytest-cov
 python-snappy
 mock
 unittest2
-xxhash==1.3.0
-parameterized==0.7.0
+xxhash>=1.3.0
+parameterized>=0.7.0
 -e git+https://github.com/Parsely/testinstances.git@0.3.0#egg=testinstances


### PR DESCRIPTION
I know that one might require upper version level bounds if the APIs of dependencies change, but this would enormously help with packaging for Linux distributions :).